### PR TITLE
fixes #19 : start and stop bitcoind from the fe

### DIFF
--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -255,6 +255,25 @@ export const monitoring = {
     get(`/makers/${id}/rpc-status`),
 };
 
+// ─── Bitcoind ─────────────────────────────────────────────────────────────────
+
+export interface BitcoindStatusInfo {
+  running: boolean;
+  network?: string;
+  managed: boolean;
+}
+
+export interface StartBitcoindRequest {
+  network: "regtest" | "signet";
+}
+
+export const bitcoind = {
+  status: (): Promise<BitcoindStatusInfo> => get("/bitcoind/status"),
+  start: (body: StartBitcoindRequest): Promise<BitcoindStatusInfo> =>
+    post("/bitcoind/start", body),
+  stop: (): Promise<BitcoindStatusInfo> => post("/bitcoind/stop"),
+};
+
 // ─── Health ───────────────────────────────────────────────────────────────────
 
 export const health = {

--- a/frontend/app/components/BitcoindWidget.tsx
+++ b/frontend/app/components/BitcoindWidget.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { bitcoind, type BitcoindStatusInfo } from "../api.ts";
+
+export default function BitcoindWidget() {
+  const [status, setStatus] = useState<BitcoindStatusInfo>({
+    running: false,
+    managed: false,
+  });
+  const [network, setNetwork] = useState<"regtest" | "signet">("regtest");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchStatus() {
+    try {
+      const s = await bitcoind.status();
+      setStatus(s);
+    } catch {
+      // silently ignore poll failures
+    }
+  }
+
+  useEffect(() => {
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 5_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  async function toggle() {
+    setPending(true);
+    setError(null);
+    try {
+      if (status.running) {
+        const s = await bitcoind.stop();
+        setStatus(s);
+      } else {
+        const s = await bitcoind.start({ network });
+        setStatus(s);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {error && (
+        <span className="text-xs text-red-400 max-w-48 truncate" title={error}>
+          {error}
+        </span>
+      )}
+
+      <div className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-900 border border-gray-800 rounded-lg">
+        <span
+          className={`w-2 h-2 rounded-full shrink-0 ${
+            status.running
+              ? "bg-orange-500 shadow-[0_0_8px_rgba(249,115,22,0.6)] animate-pulse"
+              : "bg-gray-600"
+          }`}
+        />
+        <span className="text-xs text-gray-400">
+          {status.running ? (status.network ?? "running") : "bitcoind"}
+        </span>
+      </div>
+
+      {!status.running && (
+        <select
+          value={network}
+          onChange={(e) => setNetwork(e.target.value as "regtest" | "signet")}
+          disabled={pending}
+          className="px-2 py-1.5 bg-gray-900 border border-gray-800 rounded-lg text-xs text-gray-300 focus:outline-none focus:border-orange-500 disabled:opacity-50"
+        >
+          <option value="regtest">regtest</option>
+          <option value="signet">signet</option>
+        </select>
+      )}
+
+      {(!status.running || status.managed) && (
+        <button
+          disabled={pending}
+          onClick={toggle}
+          className={`px-3 py-1.5 rounded-lg border text-xs font-medium transition-all duration-150 active:scale-[0.97] ${
+            pending
+              ? "border-gray-700 text-gray-600 cursor-not-allowed"
+              : status.running
+                ? "border-red-800 text-red-400 hover:bg-red-900/30"
+                : "border-orange-800 text-orange-400 hover:bg-orange-900/20"
+          }`}
+        >
+          {pending ? "…" : status.running ? "Stop" : "Start"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/Nav.tsx
+++ b/frontend/app/components/Nav.tsx
@@ -1,16 +1,18 @@
 import { Link } from "react-router-dom";
+import BitcoindWidget from "./BitcoindWidget.tsx";
 
 export default function Nav() {
   return (
     <header className="border-b border-gray-800 bg-gray-950 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6">
-        <div className="flex items-center h-16">
+        <div className="flex items-center justify-between h-16">
           <Link
             to="/"
             className="text-xl lg:text-3xl font-bold text-orange-500"
           >
             Coinswap Maker Dashboard
           </Link>
+          <BitcoindWidget />
         </div>
       </div>
     </header>

--- a/src/api/bitcoind.rs
+++ b/src/api/bitcoind.rs
@@ -1,0 +1,163 @@
+use axum::{extract::State, http::StatusCode, routing::get, routing::post, Json, Router};
+
+use crate::maker_manager::MakerConfig;
+
+use super::{
+    dto::{ApiResponse, BitcoindStatusInfo, StartBitcoindRequest},
+    AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/bitcoind/status", get(get_status))
+        .route("/bitcoind/start", post(start))
+        .route("/bitcoind/stop", post(stop))
+}
+
+/// Try to connect to a bitcoind RPC endpoint using a maker config.
+/// Returns the chain name (e.g. "regtest") on success.
+fn probe_rpc(config: &MakerConfig) -> Option<String> {
+    use coinswap::bitcoind::bitcoincore_rpc::{Auth, Client, RpcApi};
+
+    let auth = match &config.auth {
+        Some((u, p)) => Auth::UserPass(u.clone(), p.clone()),
+        None => Auth::None,
+    };
+    let url = format!("http://{}", config.rpc);
+    let client = Client::new(&url, auth).ok()?;
+    let info = client.get_blockchain_info().ok()?;
+    Some(info.chain.to_string())
+}
+
+/// Get bitcoind status by probing RPC connectivity via any registered maker's config.
+/// Falls back to the dashboard-managed process state if no makers are configured.
+#[utoipa::path(
+    get,
+    path = "/api/bitcoind/status",
+    tag = "bitcoind",
+    responses(
+        (status = 200, description = "Bitcoind connectivity status", body = ApiResponse<BitcoindStatusInfo>),
+    )
+)]
+async fn get_status(State(state): State<AppState>) -> Json<ApiResponse<BitcoindStatusInfo>> {
+    // Collect maker configs (drop lock before blocking work)
+    let configs: Vec<MakerConfig> = {
+        let mgr = state.lock().await;
+        mgr.list_makers()
+            .into_iter()
+            .filter_map(|id| mgr.get_config(id))
+            .collect()
+    };
+
+    // Try each maker's RPC config in a blocking thread
+    let result = tokio::task::spawn_blocking(move || {
+        for config in &configs {
+            if let Some(network) = probe_rpc(config) {
+                return Some(network);
+            }
+        }
+        None
+    })
+    .await
+    .unwrap_or(None);
+
+    // Capture managed process state once to avoid TOCTOU between branches
+    let (managed, managed_network) = state.lock().await.bitcoind_status();
+
+    if let Some(network) = result {
+        // Reachable via maker RPC config — may be an external process, not dashboard-managed
+        return Json(ApiResponse::ok(BitcoindStatusInfo {
+            running: managed,
+            network: Some(network),
+            managed,
+        }));
+    }
+
+    // No maker configs or none reachable — fall back to process tracking
+    Json(ApiResponse::ok(BitcoindStatusInfo {
+        running: managed,
+        managed,
+        network: managed_network,
+    }))
+}
+
+/// Start bitcoind in the specified network mode
+#[utoipa::path(
+    post,
+    path = "/api/bitcoind/start",
+    tag = "bitcoind",
+    request_body = StartBitcoindRequest,
+    responses(
+        (status = 200, description = "Bitcoind started", body = ApiResponse<BitcoindStatusInfo>),
+        (status = 400, description = "Invalid request or already running", body = ApiResponse<BitcoindStatusInfo>),
+    )
+)]
+async fn start(
+    State(state): State<AppState>,
+    Json(body): Json<StartBitcoindRequest>,
+) -> (StatusCode, Json<ApiResponse<BitcoindStatusInfo>>) {
+    let network = body.network.clone();
+    match state.lock().await.start_bitcoind(body.network) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(ApiResponse::ok(BitcoindStatusInfo {
+                running: true,
+                network: Some(network),
+                managed: true,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::err(e.to_string())),
+        ),
+    }
+}
+
+/// Stop the dashboard-managed bitcoind process
+#[utoipa::path(
+    post,
+    path = "/api/bitcoind/stop",
+    tag = "bitcoind",
+    responses(
+        (status = 200, description = "Bitcoind stopped", body = ApiResponse<BitcoindStatusInfo>),
+        (status = 400, description = "Bitcoind is not running", body = ApiResponse<BitcoindStatusInfo>),
+    )
+)]
+async fn stop(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<ApiResponse<BitcoindStatusInfo>>) {
+    // Take the child handle while holding the lock, then release it before blocking.
+    let child = state.lock().await.take_bitcoind();
+    let Some(mut child) = child else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::err("bitcoind is not running")),
+        );
+    };
+    // Kill and wait off the async executor so the mutex isn't held during blocking I/O.
+    let result = tokio::task::spawn_blocking(move || {
+        child
+            .kill()
+            .map_err(|e| anyhow::anyhow!("Failed to kill bitcoind: {e}"))?;
+        child
+            .wait()
+            .map_err(|e| anyhow::anyhow!("Failed to wait for bitcoind exit: {e}"))
+    })
+    .await
+    .unwrap_or_else(|e| Err(anyhow::anyhow!("spawn_blocking panicked: {e}")));
+
+    match result {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(ApiResponse::ok(BitcoindStatusInfo {
+                running: false,
+                network: None,
+                managed: false,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::err(e.to_string())),
+        ),
+    }
+}

--- a/src/api/dto.rs
+++ b/src/api/dto.rs
@@ -228,3 +228,19 @@ pub struct RpcStatusInfo {
     pub block_height: Option<u64>,
     pub sync_progress: Option<f64>,
 }
+
+/// Request body for `POST /api/bitcoind/start`
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct StartBitcoindRequest {
+    /// Network to run bitcoind on: "regtest" or "signet"
+    pub network: String,
+}
+
+/// Status of the dashboard-managed bitcoind process
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BitcoindStatusInfo {
+    pub running: bool,
+    pub network: Option<String>,
+    /// True only when bitcoind was started by the dashboard (and can be stopped via /stop)
+    pub managed: bool,
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod bitcoind;
 pub mod dto;
 pub mod fidelity;
 pub mod makers;
@@ -46,6 +47,9 @@ pub type AppState = Arc<Mutex<MakerManager>>;
         monitoring::get_tor_address,
         monitoring::get_data_dir,
         monitoring::get_rpc_status,
+        bitcoind::get_status,
+        bitcoind::start,
+        bitcoind::stop,
         health_check,
     ),
     components(schemas(
@@ -60,12 +64,15 @@ pub type AppState = Arc<Mutex<MakerManager>>;
         dto::MakerStatus,
         dto::HealthResponse,
         dto::RpcStatusInfo,
+        dto::StartBitcoindRequest,
+        dto::BitcoindStatusInfo,
     )),
     tags(
         (name = "makers", description = "Maker management"),
         (name = "wallet", description = "Wallet operations"),
         (name = "fidelity", description = "Fidelity bonds"),
         (name = "monitoring", description = "Status and monitoring"),
+        (name = "bitcoind", description = "Bitcoin node management"),
     )
 )]
 pub struct ApiDoc;
@@ -77,6 +84,7 @@ pub fn api_router() -> Router<AppState> {
         .merge(wallet::routes())
         .merge(fidelity::routes())
         .merge(monitoring::routes())
+        .merge(bitcoind::routes())
         .route("/health", get(health_check))
 }
 

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -90,6 +90,10 @@ pub struct MakerManager {
     configs: HashMap<MakerId, MakerConfig>,
     /// Handles saving/loading maker state to disk
     persistence: PersistenceManager,
+    /// Running bitcoind child process spawned by the dashboard, if any
+    bitcoind_process: Option<std::process::Child>,
+    /// Network bitcoind was started on (e.g. "regtest", "signet")
+    bitcoind_network: Option<String>,
 }
 
 impl MakerManager {
@@ -103,12 +107,14 @@ impl MakerManager {
             pool: MakerPool::new(),
             configs: HashMap::new(),
             persistence,
+            bitcoind_process: None,
+            bitcoind_network: None,
         };
 
         // Restore previously registered makers (init only, not started)
         for (id, config) in saved_configs {
             tracing::info!("Restoring maker '{}'", id);
-            match mgr.create_maker_internal(id.clone(), config, false) {
+            match mgr.create_maker_internal(id.clone(), config.clone(), false) {
                 Ok(()) => tracing::info!("Maker '{}' restored successfully (stopped)", id),
                 Err(e) => {
                     tracing::warn!(
@@ -116,6 +122,7 @@ impl MakerManager {
                         id,
                         e
                     );
+                    mgr.configs.insert(id, config);
                 }
             }
         }
@@ -244,9 +251,11 @@ impl MakerManager {
             return Err(MakerManagerError::AlreadyRunning(id.clone()));
         }
         if !self.pool.contains(id) {
-            return Err(MakerManagerError::Other(anyhow!(
-                "Maker '{id}' is not registered in the pool (needs re-init)"
-            )));
+            // Pool entry was lost (e.g. init failed at startup because bitcoind was down).
+            // Re-initialize now using the stored config.
+            let config = self.configs.get(id).cloned().expect("checked above");
+            self.create_maker_internal(id.clone(), config, false)
+                .map_err(MakerManagerError::Other)?;
         }
         self.pool.start_server(id).map_err(MakerManagerError::Other)
     }
@@ -468,6 +477,75 @@ impl MakerManager {
             .config_dir
             .join("logs")
             .join(format!("maker-{maker_id}.log"))
+    }
+
+    /// Starts a bitcoind process in the given network mode ("regtest" or "signet").
+    /// Binary path is read from the `BITCOIND_EXE` environment variable; defaults to "bitcoind" on $PATH.
+    pub fn start_bitcoind(&mut self, network: String) -> Result<()> {
+        // Clean up a previously-exited process handle, if any
+        if let Some(ref mut child) = self.bitcoind_process {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    self.bitcoind_process = None;
+                    self.bitcoind_network = None;
+                }
+                Ok(None) => return Err(anyhow!("bitcoind is already running")),
+                Err(e) => return Err(anyhow!("Failed to check bitcoind process status: {e}")),
+            }
+        }
+
+        if !matches!(network.as_str(), "regtest" | "signet") {
+            return Err(anyhow!(
+                "Invalid network '{network}'. Must be 'regtest' or 'signet'."
+            ));
+        }
+
+        let exe = std::env::var("BITCOIND_EXE").unwrap_or_else(|_| "bitcoind".to_string());
+        let child = std::process::Command::new(&exe)
+            .arg(format!("-{network}"))
+            .arg("-server")
+            .spawn()
+            .map_err(|e| anyhow!("Failed to spawn bitcoind ('{exe}'): {e}"))?;
+
+        self.bitcoind_process = Some(child);
+        self.bitcoind_network = Some(network);
+        Ok(())
+    }
+
+    /// Extracts the dashboard-managed bitcoind child handle for async-safe shutdown.
+    /// Returns `None` if no process is currently tracked as running.
+    /// The caller is responsible for calling `kill()` and `wait()` on the returned handle.
+    pub fn take_bitcoind(&mut self) -> Option<std::process::Child> {
+        let child = self.bitcoind_process.take()?;
+        self.bitcoind_network = None;
+        Some(child)
+    }
+
+    /// Returns `(running, network)` for the dashboard-managed bitcoind process.
+    pub fn bitcoind_status(&mut self) -> (bool, Option<String>) {
+        if let Some(ref mut child) = self.bitcoind_process {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    // Process exited on its own
+                    self.bitcoind_process = None;
+                    self.bitcoind_network = None;
+                    (false, None)
+                }
+                Ok(None) => (true, self.bitcoind_network.clone()),
+                Err(_) => (false, None),
+            }
+        } else {
+            (false, None)
+        }
+    }
+}
+
+impl Drop for MakerManager {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.bitcoind_process.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bitcoind daemon management — start, stop, and monitor status directly from the dashboard with real-time updates
  * New status widget in the header displaying bitcoind running state and selected network
  * Automatic status polling with manual start/stop controls
  * Network selection for regtest and signet
  * Dashboard-managed bitcoind lifecycle (start/stop tracking and graceful termination)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->