### PR TITLE
cli: change default `log_filter`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,7 @@ pub struct Cli {
     /// Log filter directive (e.g. "debug", "tower_http=debug,info")
     #[arg(
         long,
-        default_value = "tower_http=info,debug",
+        default_value = "tower_http=debug,info",
         env = "DASHBOARD_LOG_FILTER"
     )]
     pub log_filter: String,


### PR DESCRIPTION
Close #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the default logging filter order to optimize log output organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->