### PR TITLE
refactor(frontend): replace emojis with lucide icons

### DIFF
--- a/frontend/app/routes/addMaker.tsx
+++ b/frontend/app/routes/addMaker.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { X } from "lucide-react";
 import Nav from "../components/Nav";
 import { makers, type CreateMakerRequest, ApiError } from "../api";
 
@@ -105,7 +106,7 @@ export default function AddMaker() {
               onClick={() => setError(null)}
               className="ml-4 text-red-400 hover:text-red-200 font-bold"
             >
-              ✕
+              <X className="w-4 h-4" />
             </button>
           </div>
         )}

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { X } from "lucide-react";
 import Nav from "../components/Nav";
 import OnboardingWizard from "./onboarding";
 import {
@@ -122,7 +123,7 @@ export default function Home() {
               onClick={() => setError(null)}
               className="ml-4 text-red-400 hover:text-red-200 font-bold"
             >
-              ✕
+              <X className="w-4 h-4" />
             </button>
           </div>
         )}

--- a/frontend/app/routes/makerDetails/index.tsx
+++ b/frontend/app/routes/makerDetails/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "react-router-dom";
+import { Zap, Moon } from "lucide-react";
 import Nav from "../../components/Nav";
 import {
   makers,
@@ -202,7 +203,11 @@ export default function MakerDetails() {
           <div className="flex flex-col sm:flex-row justify-between gap-4">
             <div className="flex items-center gap-4">
               <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center text-2xl">
-                {isRunning ? "⚡" : "💤"}
+                {isRunning ? (
+                  <Zap className="w-6 h-6" />
+                ) : (
+                  <Moon className="w-6 h-6" />
+                )}
               </div>
               <div>
                 <div className="text-sm text-orange-100 mb-1">Status</div>

--- a/frontend/app/routes/makerDetails/log.tsx
+++ b/frontend/app/routes/makerDetails/log.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { Circle } from "lucide-react";
 import { monitoring, streamLogs, downloadLogs } from "../../api";
 
 interface Props {
@@ -156,7 +157,14 @@ export default function Logs({ id }: Props) {
                   : "bg-gray-800 text-gray-400"
               }`}
             >
-              {streaming ? "● Live" : "Static"}
+              {streaming ? (
+                <>
+                  <Circle className="w-2 h-2 fill-current inline-block mr-1" />{" "}
+                  Live
+                </>
+              ) : (
+                "Static"
+              )}
             </span>
           </div>
         </div>

--- a/frontend/app/routes/makerDetails/settings.tsx
+++ b/frontend/app/routes/makerDetails/settings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Check, X as XIcon } from "lucide-react";
 import {
   makers,
   monitoring,
@@ -722,7 +723,7 @@ export default function Settings({ id, onSaved }: Props) {
             <div className="space-y-3 mb-6">
               {[
                 {
-                  icon: "✓",
+                  icon: <Check className="w-4 h-4" />,
                   color: "text-green-400",
                   text: (
                     <>
@@ -732,12 +733,12 @@ export default function Settings({ id, onSaved }: Props) {
                   ),
                 },
                 {
-                  icon: "✓",
+                  icon: <Check className="w-4 h-4" />,
                   color: "text-green-400",
                   text: "Stops the maker process if it is currently running",
                 },
                 {
-                  icon: "✗",
+                  icon: <XIcon className="w-4 h-4" />,
                   color: "text-red-400",
                   text: (
                     <>
@@ -747,7 +748,7 @@ export default function Settings({ id, onSaved }: Props) {
                   ),
                 },
                 {
-                  icon: "✗",
+                  icon: <XIcon className="w-4 h-4" />,
                   color: "text-red-400",
                   text: (
                     <>
@@ -757,7 +758,7 @@ export default function Settings({ id, onSaved }: Props) {
                   ),
                 },
                 {
-                  icon: "✗",
+                  icon: <XIcon className="w-4 h-4" />,
                   color: "text-red-400",
                   text: 'Cannot undo blockchain transactions — nothing on-chain is ever "deleted"',
                 },

--- a/frontend/app/routes/makersetup.tsx
+++ b/frontend/app/routes/makersetup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { Bitcoin, Check, X } from "lucide-react";
 import Nav from "../components/Nav";
 import { makers, monitoring, wallet, streamLogs, ApiError } from "../api";
 
@@ -232,8 +233,8 @@ export default function MakerSetup() {
     },
     awaiting_funds: {
       icon: (
-        <div className="w-16 h-16 rounded-full bg-orange-500/10 border-2 border-orange-500 flex items-center justify-center text-3xl">
-          ₿
+        <div className="w-16 h-16 rounded-full bg-orange-500/10 border-2 border-orange-500 flex items-center justify-center">
+          <Bitcoin className="w-8 h-8 text-orange-500" />
         </div>
       ),
       title: "Deposit Required",
@@ -270,8 +271,8 @@ export default function MakerSetup() {
     },
     live: {
       icon: (
-        <div className="w-16 h-16 rounded-full bg-emerald-500/10 border-2 border-emerald-500 flex items-center justify-center text-3xl">
-          ✓
+        <div className="w-16 h-16 rounded-full bg-emerald-500/10 border-2 border-emerald-500 flex items-center justify-center">
+          <Check className="w-8 h-8 text-emerald-500" />
         </div>
       ),
       title: "Maker is Live!",
@@ -280,8 +281,8 @@ export default function MakerSetup() {
     },
     error: {
       icon: (
-        <div className="w-16 h-16 rounded-full bg-red-500/10 border-2 border-red-500 flex items-center justify-center text-3xl">
-          ✕
+        <div className="w-16 h-16 rounded-full bg-red-500/10 border-2 border-red-500 flex items-center justify-center">
+          <X className="w-8 h-8 text-red-500" />
         </div>
       ),
       title: "Setup Failed",
@@ -355,7 +356,7 @@ export default function MakerSetup() {
                           : "bg-gray-800 text-gray-500"
                     }`}
                   >
-                    {isDone ? "✓" : i + 1}
+                    {isDone ? <Check className="w-4 h-4" /> : i + 1}
                   </div>
                   <span
                     className={`text-xs ${isActive ? "text-orange-400" : isDone ? "text-emerald-400" : "text-gray-500"}`}

--- a/frontend/app/routes/onboarding.tsx
+++ b/frontend/app/routes/onboarding.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { Check, X, Zap, ShieldCheck, Coins, Globe } from "lucide-react";
 import Nav from "../components/Nav";
 import { makers, type CreateMakerRequest, ApiError } from "../api.ts";
 
@@ -30,7 +31,7 @@ function StepIndicator({ current }: { current: OnboardStep }) {
                     : "bg-gray-800 text-gray-500"
               }`}
             >
-              {i < idx ? "✓" : i + 1}
+              {i < idx ? <Check className="w-4 h-4" /> : i + 1}
             </div>
             <span
               className={`text-xs mt-1.5 font-medium ${i === idx ? "text-orange-400" : "text-gray-500"}`}
@@ -54,7 +55,9 @@ function StepIndicator({ current }: { current: OnboardStep }) {
 function WelcomeStep({ onNext }: { onNext: () => void }) {
   return (
     <div className="max-w-2xl mx-auto text-center">
-      <div className="text-6xl mb-6">⚡</div>
+      <div className="mb-6">
+        <Zap className="w-14 h-14 text-orange-500" />
+      </div>
       <h2 className="text-3xl font-bold mb-3">Welcome to Coinswap Maker</h2>
       <p className="text-gray-400 mb-8 text-lg leading-relaxed">
         A <strong className="text-gray-200">maker</strong> is a node that
@@ -65,17 +68,17 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10 text-left">
         {[
           {
-            icon: "🔐",
+            icon: <ShieldCheck className="w-6 h-6 text-orange-400" />,
             title: "Privacy-first",
             desc: "Coinswap breaks the transaction graph without requiring a trusted third party.",
           },
           {
-            icon: "💰",
+            icon: <Coins className="w-6 h-6 text-orange-400" />,
             title: "Earn fees",
             desc: "You earn a base fee + a percentage of each swap amount for providing liquidity.",
           },
           {
-            icon: "🌐",
+            icon: <Globe className="w-6 h-6 text-orange-400" />,
             title: "Tor native",
             desc: "Makers advertise over Tor — it's how takers find you and how all swap communication works.",
           },
@@ -84,7 +87,7 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
             key={f.title}
             className="bg-gray-800 rounded-xl p-4 border border-gray-700"
           >
-            <div className="text-2xl mb-2">{f.icon}</div>
+            <div className="mb-2">{f.icon}</div>
             <div className="font-semibold text-gray-100 mb-1">{f.title}</div>
             <div className="text-sm text-gray-400">{f.desc}</div>
           </div>
@@ -169,9 +172,7 @@ function PrereqsStep({
                     : "border-gray-600"
                 }`}
               >
-                {checked[p.id] && (
-                  <span className="text-white text-xs font-bold">✓</span>
-                )}
+                {checked[p.id] && <Check className="w-3.5 h-3.5 text-white" />}
               </div>
               <div className="flex-1 min-w-0">
                 <div className="font-semibold text-gray-100 mb-1">
@@ -272,7 +273,7 @@ function CreateStep({ onBack }: { onBack: () => void }) {
             onClick={() => setError(null)}
             className="ml-4 text-red-400 font-bold"
           >
-            ✕
+            <X className="w-4 h-4" />
           </button>
         </div>
       )}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "coinswap-maker-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.577.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-router-dom": "^7.12.0"
@@ -3183,6 +3184,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "lucide-react": "^0.577.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router-dom": "^7.12.0"


### PR DESCRIPTION
This removes all emojis in the frontend and replace it with [lucide icons](https://lucide.dev/icons/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced text glyphs and emoji characters with Lucide React SVG icons across the app—status indicators, live/stream labels, dismiss buttons, progress steps, modal bullets, and feature cards—for a more consistent, scalable visual presentation.

* **Chores**
  * Added the lucide-react icon library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->