### PR TITLE
show makers running swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ By default the dashboard only accepts connections from the local machine. If you
 Dashboard-managed files:
 
 - Registered maker configs: `~/.config/maker-dashboard/makers.json`
-- Per-maker logs: `~/.config/maker-dashboard/logs/maker-{id}.log`
+- Per-maker logs: `~/.coinswap/{id}/debug.log`
 
 Maker wallet and data directories are configured per maker and may differ from the dashboard config directory.
 

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -113,6 +113,11 @@ export interface MakerFeeInfo {
   total_fee: number;
 }
 
+export interface CombinedLogLine {
+  maker_id: string;
+  line: string;
+}
+
 export interface SwapReportDto {
   swap_id: string;
   role: string;
@@ -354,6 +359,8 @@ export const monitoring = {
   /** Tests connectivity to the maker's configured Bitcoin Core RPC endpoint */
   rpcStatus: (id: string): Promise<RpcStatusInfo> =>
     get(`/makers/${id}/rpc-status`),
+  combinedLogs: (lines?: number): Promise<CombinedLogLine[]> =>
+    get(`/logs/combined${lines !== undefined ? `?lines=${lines}` : ""}`),
 };
 
 // ─── Bitcoind ─────────────────────────────────────────────────────────────────

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -75,6 +75,20 @@ body {
   animation: shimmer 1.8s ease-in-out infinite;
 }
 
+@keyframes swap-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 10px 2px rgba(249, 115, 22, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 22px 6px rgba(249, 115, 22, 0.55);
+  }
+}
+
+@utility animate-swap-glow {
+  animation: swap-glow 2s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -7,6 +7,7 @@ import {
   makers,
   wallet,
   monitoring,
+  streamLogs,
   satsToBtc,
   type MakerInfoDetailed,
   type BalanceInfo,
@@ -31,6 +32,7 @@ interface MakerRow {
 }
 
 const SWAP_HISTORY_REFRESH_MS = 60_000;
+const TRANSIENT_SWAP_SIGNAL_MS = 30_000;
 type MakerFilter = "all" | "running";
 
 function swapKey(
@@ -47,6 +49,13 @@ function truncateMiddle(value: string, start = 18, end = 14) {
   return `${value.slice(0, start)}...${value.slice(-end)}`;
 }
 
+const SWAP_LOG_KEYWORDS = ["new connection from"];
+
+function isSwapLogLine(line: string): boolean {
+  const lower = line.toLowerCase();
+  return SWAP_LOG_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function Home() {
@@ -55,6 +64,10 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Set<string>>(new Set());
+  const [logSwapSeenAt, setLogSwapSeenAt] = useState<Record<string, number>>(
+    {},
+  );
+  const [swapBannerDismissed, setSwapBannerDismissed] = useState(false);
   const swapHistoryCache = useRef<Record<string, UtxoInfo[]>>({});
   const swapReportCache = useRef<Record<string, SwapReportDto[]>>({});
   const lastSwapRefreshAt = useRef(0);
@@ -148,6 +161,52 @@ export default function Home() {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const runningIds = new Set(
+      makerRows
+        .filter((maker) => maker.state === "running")
+        .map((maker) => maker.id),
+    );
+
+    setLogSwapSeenAt((prev) => {
+      const next = Object.fromEntries(
+        Object.entries(prev).filter(([id]) => runningIds.has(id)),
+      );
+      return Object.keys(next).length === Object.keys(prev).length
+        ? prev
+        : next;
+    });
+
+    const stops = Array.from(runningIds).map((id) =>
+      streamLogs(id, (line) => {
+        if (!isSwapLogLine(line)) return;
+        setSwapBannerDismissed(false);
+        setLogSwapSeenAt((prev) => {
+          return { ...prev, [id]: Date.now() };
+        });
+      }),
+    );
+
+    const pruneInterval = setInterval(() => {
+      setLogSwapSeenAt((prev) => {
+        const cutoff = Date.now() - TRANSIENT_SWAP_SIGNAL_MS;
+        const next = Object.fromEntries(
+          Object.entries(prev).filter(
+            ([id, seenAt]) => runningIds.has(id) && seenAt >= cutoff,
+          ),
+        );
+        return Object.keys(next).length === Object.keys(prev).length
+          ? prev
+          : next;
+      });
+    }, 5_000);
+
+    return () => {
+      clearInterval(pruneInterval);
+      for (const stop of stops) stop();
+    };
+  }, [makerRows]);
+
   async function toggleMaker(id: string, currentState: MakerState) {
     setPending((prev) => new Set(prev).add(id));
     try {
@@ -201,11 +260,40 @@ export default function Home() {
     makerFilter === "running"
       ? makerRows.filter((m) => m.state === "running")
       : makerRows;
+  const swapSignalCutoff = Date.now() - TRANSIENT_SWAP_SIGNAL_MS;
+
+  const anySwapping = makerRows.some(
+    (m) =>
+      m.swapActive.length > 0 ||
+      (m.state === "running" && (logSwapSeenAt[m.id] ?? 0) >= swapSignalCutoff),
+  );
+  const showSwapBanner = anySwapping && !swapBannerDismissed;
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100">
       <Nav />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-8 animate-slide-in-up">
+        {showSwapBanner && (
+          <div className="mb-6 px-4 py-3 bg-orange-950/60 border border-orange-500 rounded-lg text-sm text-orange-200 flex justify-between items-center gap-3 sticky top-4 z-10 backdrop-blur-sm shadow-lg shadow-orange-500/10">
+            <div className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-orange-400 animate-pulse shrink-0" />
+              <span>
+                <strong>
+                  One or more makers are currently in an active swap.
+                </strong>{" "}
+                Do not reload the page or remove a maker until the swap
+                completes.
+              </span>
+            </div>
+            <button
+              onClick={() => setSwapBannerDismissed(true)}
+              className="shrink-0 text-orange-400 hover:text-orange-200 transition-colors"
+              aria-label="Dismiss swap warning"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        )}
         {error && (
           <div className="mb-6 px-4 py-3 bg-red-900/40 border border-red-700 rounded-lg text-sm text-red-300 flex justify-between items-center">
             <span>{error}</span>
@@ -319,7 +407,10 @@ export default function Home() {
               {visibleMakerRows.map((maker) => {
                 const isRunning = maker.state === "running";
                 const isPending = pending.has(maker.id);
-                const isSwapping = maker.swapActive.length > 0;
+                const isSwapping =
+                  maker.swapActive.length > 0 ||
+                  (maker.state === "running" &&
+                    (logSwapSeenAt[maker.id] ?? 0) >= swapSignalCutoff);
                 return (
                   <div
                     key={maker.id}
@@ -332,7 +423,7 @@ export default function Home() {
                     <div className="flex items-center justify-between mb-3 sm:mb-4">
                       <div className="flex items-center gap-2">
                         <span
-                          className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${
+                          className={`w-2.5 h-2.5 rounded-full shrink-0 ${
                             maker.alive
                               ? "bg-green-500 shadow-[0_0_10px_rgba(34,197,94,0.5)] animate-pulse"
                               : "bg-gray-600"

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -26,6 +26,7 @@ interface MakerRow {
   dataDir: string | null;
   earningsSats: number | null;
   swapReportCount: number | null;
+  swapActive: UtxoInfo[];
   swapCompleted: UtxoInfo[];
 }
 
@@ -98,6 +99,8 @@ export default function Home() {
               : null;
           const swapReports =
             reports.status === "fulfilled" ? reports.value : null;
+          const swapActive =
+            swaps.status === "fulfilled" ? swaps.value.active : [];
           const swapCompleted =
             swaps.status === "fulfilled" ? swaps.value.completed : [];
           const earningsSats =
@@ -121,6 +124,7 @@ export default function Home() {
             dataDir,
             earningsSats,
             swapReportCount,
+            swapActive,
             swapCompleted,
           };
         }),
@@ -315,10 +319,15 @@ export default function Home() {
               {visibleMakerRows.map((maker) => {
                 const isRunning = maker.state === "running";
                 const isPending = pending.has(maker.id);
+                const isSwapping = maker.swapActive.length > 0;
                 return (
                   <div
                     key={maker.id}
-                    className="group bg-gray-900 border border-gray-800 rounded-xl p-4 sm:p-5 hover:border-orange-500 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-orange-500/10 transition-all duration-200"
+                    className={`group bg-gray-900 border rounded-xl p-4 sm:p-5 hover:-translate-y-0.5 transition-all duration-200 ${
+                      isSwapping
+                        ? "border-orange-500 animate-swap-glow hover:shadow-xl hover:shadow-orange-500/20"
+                        : "border-gray-800 hover:border-orange-500 hover:shadow-lg hover:shadow-orange-500/10"
+                    }`}
                   >
                     <div className="flex items-center justify-between mb-3 sm:mb-4">
                       <div className="flex items-center gap-2">
@@ -333,15 +342,23 @@ export default function Home() {
                           {maker.id}
                         </h3>
                       </div>
-                      <span
-                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                          isRunning
-                            ? "bg-emerald-900/50 text-emerald-400"
-                            : "bg-gray-800 text-gray-500"
-                        }`}
-                      >
-                        {isRunning ? "Running" : "Stopped"}
-                      </span>
+                      <div className="flex items-center gap-2">
+                        {isSwapping && (
+                          <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium bg-orange-900/50 text-orange-400 animate-pulse">
+                            <span className="w-1.5 h-1.5 rounded-full bg-orange-400" />
+                            Swap Active
+                          </span>
+                        )}
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                            isRunning
+                              ? "bg-emerald-900/50 text-emerald-400"
+                              : "bg-gray-800 text-gray-500"
+                          }`}
+                        >
+                          {isRunning ? "Running" : "Stopped"}
+                        </span>
+                      </div>
                     </div>
 
                     {maker.torAddress && (

--- a/frontend/app/routes/makerDetails/log.tsx
+++ b/frontend/app/routes/makerDetails/log.tsx
@@ -109,7 +109,7 @@ export default function Logs({ id }: Props) {
     logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [logs]);
 
-  const logPath = dataDir ? `${dataDir}/maker-${id}.log` : null;
+  const logPath = dataDir ? `${dataDir}/debug.log` : null;
 
   function copyPath() {
     if (!logPath) return;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coinswap-maker-dashboard",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coinswap-maker-dashboard",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "lucide-react": "^0.577.0",
         "react": "^19.2.3",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,7 +24,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./app/*"],
       "@components/*": ["./app/components/*"],

--- a/src/api/dto.rs
+++ b/src/api/dto.rs
@@ -388,6 +388,13 @@ pub struct StartBitcoindRequest {
     pub network: String,
 }
 
+/// A single log line tagged with the maker it came from.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CombinedLogLine {
+    pub maker_id: String,
+    pub line: String,
+}
+
 /// Status of the dashboard-managed bitcoind process
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BitcoindStatusInfo {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -49,6 +49,7 @@ pub type AppState = Arc<Mutex<MakerManager>>;
         monitoring::get_tor_address,
         monitoring::get_data_dir,
         monitoring::get_rpc_status,
+        monitoring::get_combined_logs,
         bitcoind::get_status,
         bitcoind::start,
         bitcoind::stop,
@@ -73,6 +74,7 @@ pub type AppState = Arc<Mutex<MakerManager>>;
         dto::StartupCheckResponse,
         dto::StartBitcoindRequest,
         dto::BitcoindStatusInfo,
+        dto::CombinedLogLine,
     )),
     tags(
         (name = "makers", description = "Maker management"),

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -20,7 +20,10 @@ use crate::maker_manager::message::MessageResponse;
 use crate::utils::log_writer::read_last_n_lines;
 
 use super::{
-    dto::{ApiResponse, MakerStatus, RpcStatusInfo, SwapHistoryDto, SwapReportDto, UtxoInfo},
+    dto::{
+        ApiResponse, CombinedLogLine, MakerStatus, RpcStatusInfo, SwapHistoryDto, SwapReportDto,
+        UtxoInfo,
+    },
     AppState,
 };
 
@@ -35,6 +38,7 @@ pub fn routes() -> Router<AppState> {
         .route("/makers/{id}/tor-address", get(get_tor_address))
         .route("/makers/{id}/data-dir", get(get_data_dir))
         .route("/makers/{id}/rpc-status", get(get_rpc_status))
+        .route("/logs/combined", get(get_combined_logs))
 }
 
 /// Get operational status of a maker
@@ -481,6 +485,45 @@ async fn get_rpc_status(
             Json(ApiResponse::err(e.to_string())),
         ),
     }
+}
+
+/// Get combined log lines from all makers, each tagged with maker_id.
+#[utoipa::path(
+    get,
+    path = "/api/logs/combined",
+    tag = "monitoring",
+    params(
+        ("lines" = Option<usize>, Query, description = "Number of tail lines per maker (default 100)")
+    ),
+    responses(
+        (status = 200, description = "Combined log lines", body = ApiResponse<Vec<CombinedLogLine>>)
+    )
+)]
+async fn get_combined_logs(
+    State(state): State<AppState>,
+    Query(query): Query<LogsQuery>,
+) -> (StatusCode, Json<ApiResponse<Vec<CombinedLogLine>>>) {
+    let n = query.lines.unwrap_or(100);
+    let maker_paths: Vec<(String, std::path::PathBuf)> = {
+        let manager = state.lock().await;
+        manager
+            .list_makers()
+            .into_iter()
+            .map(|id| (id.clone(), manager.log_file_path(id)))
+            .collect()
+    };
+    let mut all_lines: Vec<CombinedLogLine> = Vec::new();
+    for (maker_id, path) in maker_paths {
+        match read_last_n_lines(&path, n) {
+            Ok(lines) => all_lines.extend(lines.into_iter().map(|line| CombinedLogLine {
+                maker_id: maker_id.clone(),
+                line,
+            })),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!("Failed to read logs for maker '{maker_id}': {e}"),
+        }
+    }
+    (StatusCode::OK, Json(ApiResponse::ok(all_lines)))
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,7 @@ async fn main() {
         .config_dir
         .unwrap_or_else(maker_dashboard::utils::default_config_dir);
 
-    let log_dir = config_dir.join("logs");
-
-    let log_writer = MakerLogWriter::new(&log_dir);
+    let log_writer = MakerLogWriter::new();
 
     tracing_subscriber::registry()
         .with(
@@ -36,8 +34,6 @@ async fn main() {
         .init();
 
     tracing::info!("Using config directory: {}", config_dir.display());
-    tracing::info!("Maker logs directory: {}", log_dir.display());
-
     let config = ServerConfig {
         host: args.host,
         port: args.port,

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -7,6 +7,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::utils::log_writer::MakerLogWriter;
 use anyhow::{anyhow, Result};
 use coinswap::bitcoin::Network;
 use coinswap::bitcoind::bitcoincore_rpc::Auth;
@@ -225,6 +226,7 @@ impl MakerManager {
             .data_directory
             .clone()
             .expect("maker data directory is initialized above");
+        MakerLogWriter::register_maker(&id, &data_dir)?;
         let wallet_name = config.wallet_name.clone().unwrap_or_else(|| id.clone());
         let network = self.infer_network(&config.rpc);
         let maker = Arc::new(
@@ -557,6 +559,7 @@ impl MakerManager {
     /// Removes a maker entirely (stops server, removes from pool, deletes config)
     pub fn remove_maker(&mut self, id: &MakerId) -> bool {
         self.pool.remove_maker(id);
+        MakerLogWriter::unregister_maker(id);
         let removed = self.configs.remove(id).is_some();
         if removed {
             self.persist();
@@ -583,10 +586,11 @@ impl MakerManager {
 
     /// Returns the log file path for a given maker ID.
     pub fn log_file_path(&self, maker_id: &str) -> std::path::PathBuf {
-        self.persistence
-            .config_dir
-            .join("logs")
-            .join(format!("maker-{maker_id}.log"))
+        self.configs
+            .get(maker_id)
+            .and_then(|config| config.data_directory.clone())
+            .unwrap_or_else(|| Self::default_maker_data_dir(&maker_id.to_string()))
+            .join("debug.log")
     }
 
     /// Starts a bitcoind process in the given network mode ("regtest" or "signet").

--- a/src/utils/log_writer.rs
+++ b/src/utils/log_writer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use tracing_subscriber::fmt::MakeWriter;
 
@@ -37,25 +37,21 @@ impl Write for LogWriter {
 
 /// A `MakeWriter` implementation that routes logs to per-maker files
 /// based on the current thread name. Threads named `maker-{id}` get their own
-/// log file under `{log_dir}/maker-{id}.log`.
+/// log file under the maker data directory as `debug.log`.
 /// All other threads write to stdout.
 #[derive(Clone)]
-pub struct MakerLogWriter {
-    log_dir: PathBuf,
-}
+pub struct MakerLogWriter;
 
-/// Global cache of open file handles, keyed by maker id.
-static FILE_CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+/// Global cache of maker log paths, keyed by maker id.
+static LOG_PATHS: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
 
-fn file_cache() -> &'static Mutex<HashMap<String, PathBuf>> {
-    FILE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+fn log_paths() -> &'static Mutex<HashMap<String, PathBuf>> {
+    LOG_PATHS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 impl MakerLogWriter {
-    pub fn new(log_dir: impl Into<PathBuf>) -> Self {
-        let log_dir = log_dir.into();
-        fs::create_dir_all(&log_dir).expect("Failed to create log directory");
-        Self { log_dir }
+    pub fn new() -> Self {
+        Self
     }
 
     /// Extracts the maker id from thread names like `maker-mymaker`.
@@ -66,11 +62,32 @@ impl MakerLogWriter {
             .map(|id| id.to_string())
     }
 
+    pub fn register_maker(id: &str, data_dir: &Path) -> io::Result<()> {
+        fs::create_dir_all(data_dir)?;
+        let mut paths = log_paths().lock().unwrap();
+        paths.insert(id.to_string(), data_dir.join("debug.log"));
+        Ok(())
+    }
+
+    pub fn unregister_maker(id: &str) {
+        let mut paths = log_paths().lock().unwrap();
+        paths.remove(id);
+    }
+
     fn open_log_file(&self, maker_id: &str) -> io::Result<File> {
-        let mut cache = file_cache().lock().unwrap();
-        let path = cache
-            .entry(maker_id.to_string())
-            .or_insert_with(|| self.log_dir.join(format!("maker-{maker_id}.log")));
+        let path = {
+            let paths = log_paths().lock().unwrap();
+            paths.get(maker_id).cloned().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("No registered log path for maker '{maker_id}'"),
+                )
+            })?
+        };
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
 
         OpenOptions::new().create(true).append(true).open(path)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maker cards show an orange “Swap Active” pill and glowing border animation when swaps are detected
  * Sticky, dismissible page-level swap warning banner for active/recent swaps
  * New combined-logs endpoint to fetch recent log lines across makers

* **Documentation**
  * README updated with the new per-maker log file location

* **Chores**
  * Backend now registers per-maker log locations; UI “Copy path” updated to the new debug.log path
<!-- end of auto-generated comment: release notes by coderabbit.ai -->