### PR TITLE
make tor hostname copiable

### DIFF
--- a/frontend/app/routes/makerDetails/index.tsx
+++ b/frontend/app/routes/makerDetails/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "react-router-dom";
-import { Zap, Moon } from "lucide-react";
+import { Zap, Moon, Copy, Check } from "lucide-react";
 import Nav from "../../components/Nav";
 import {
   makers,
@@ -51,6 +51,18 @@ export default function MakerDetails() {
   const [syncLoading, setSyncLoading] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
   const [walletRefreshToken, setWalletRefreshToken] = useState(0);
+  const [copiedTor, setCopiedTor] = useState(false);
+
+  function copyTorAddress() {
+    if (!torAddress) return;
+    navigator.clipboard
+      .writeText(torAddress)
+      .then(() => {
+        setCopiedTor(true);
+        setTimeout(() => setCopiedTor(false), 2000);
+      })
+      .catch(() => {});
+  }
 
   const loadCore = useCallback(async () => {
     if (!id) return;
@@ -249,13 +261,29 @@ export default function MakerDetails() {
                 </div>
               </div>
             </div>
-            <div className="sm:max-w-xs">
+            <div className="sm:max-w-xs flex flex-col items-start min-w-0">
               <div className="text-sm text-orange-100 mb-1">Tor Hostname</div>
-              <div
-                className="text-xs sm:text-sm font-mono text-white bg-white/10 px-3 py-2 rounded-lg break-all"
-                title={torAddress ?? undefined}
-              >
-                {torAddress ? truncateMiddle(torAddress) : "—"}
+              <div className="flex items-center gap-2 w-full">
+                <div
+                  className="text-xs sm:text-sm font-mono text-white bg-white/10 px-3 py-2 rounded-lg break-all flex-1"
+                  title={torAddress ?? undefined}
+                >
+                  {torAddress ? truncateMiddle(torAddress) : "—"}
+                </div>
+                {torAddress && (
+                  <button
+                    type="button"
+                    onClick={copyTorAddress}
+                    title={copiedTor ? "Copied!" : "Copy to clipboard"}
+                    className="shrink-0 p-1.5 bg-black/20 hover:bg-black/30 rounded-lg transition-all duration-150"
+                  >
+                    {copiedTor ? (
+                      <Check className="w-4 h-4 text-green-400" />
+                    ) : (
+                      <Copy className="w-4 h-4 text-white" />
+                    )}
+                  </button>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
<img width="1326" height="351" alt="Screenshot 2026-04-21 at 15 26 57" src="https://github.com/user-attachments/assets/29086129-3fc6-4a92-a513-8b75268d3a59" />
<img width="1109" height="287" alt="Screenshot 2026-04-21 at 15 26 22" src="https://github.com/user-attachments/assets/788d6a50-c3e1-4c82-9870-e5514c565a58" />

Fixes - #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conditional Copy button to the Tor Hostname section (visible only when an address exists).  
  * Copy action shows a temporary "Copied" confirmation for two seconds; button icon and tooltip update to reflect status.  
  * Improved Tor Hostname layout so the address better fills available width for clearer display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

