### PR TITLE
fix: bind RPC and ZMQ to 0.0.0.0 for host accessibility

### DIFF
--- a/docker/bitcoin.conf
+++ b/docker/bitcoin.conf
@@ -9,15 +9,15 @@ server=1
 rpcuser=user
 rpcpassword=password
 rpcport=38332
-rpcbind=127.0.0.1
-rpcallowip=127.0.0.1
+rpcbind=0.0.0.0
+rpcallowip=0.0.0.0/0
 
 # REST interface
 rest=1
 
 # ZMQ for block/tx notifications
-zmqpubrawblock=tcp://127.0.0.1:28332
-zmqpubrawtx=tcp://127.0.0.1:28332
+zmqpubrawblock=tcp://0.0.0.0:28332
+zmqpubrawtx=tcp://0.0.0.0:28332
 
 # Indexes
 txindex=1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bitcoin service network configuration. RPC listener now binds to all network interfaces and accepts incoming connections from any IP address, replacing localhost-only restrictions. ZMQ notification endpoints for block and transaction data now broadcast on all available network interfaces instead of localhost only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->