### PR TITLE
ci: automate upgraing coinswap

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -1,0 +1,8 @@
+# Project maintainers.
+# One GitHub handle per line, without the leading '@'.
+# Lines starting with '#' and blank lines are ignored.
+# Used by automated workflows (e.g. .github/workflows/update-coinswap.yml)
+# to request reviews on bot-authored PRs.
+
+keraliss
+hulxv

--- a/.github/workflows/update-coinswap.yml
+++ b/.github/workflows/update-coinswap.yml
@@ -1,0 +1,126 @@
+name: Update coinswap dependency
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Check and update coinswap rev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve current and upstream coinswap revs
+        id: revs
+        run: |
+          set -euo pipefail
+
+          current_full=$(grep -E '^coinswap\s*=\s*\{' Cargo.toml \
+            | sed -nE 's/.*rev\s*=\s*"([0-9a-f]+)".*/\1/p')
+          if [ -z "$current_full" ]; then
+            echo "::error::Could not parse current coinswap rev from Cargo.toml"
+            exit 1
+          fi
+
+          latest_full=$(git ls-remote https://github.com/citadel-tech/coinswap HEAD \
+            | awk '{print $1}')
+          if [ -z "$latest_full" ]; then
+            echo "::error::Could not resolve upstream HEAD via git ls-remote"
+            exit 1
+          fi
+
+          short_len=${#current_full}
+          latest_short=${latest_full:0:$short_len}
+
+          echo "current=$current_full"        >> "$GITHUB_OUTPUT"
+          echo "latest=$latest_full"          >> "$GITHUB_OUTPUT"
+          echo "latest_short=$latest_short"   >> "$GITHUB_OUTPUT"
+
+          if [ "$current_full" = "$latest_short" ] || [ "${latest_full:0:${#current_full}}" = "$current_full" ]; then
+            echo "up_to_date=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Current pin: $current_full"
+          echo "Upstream HEAD: $latest_full"
+
+      - name: Skip if already up to date
+        if: steps.revs.outputs.up_to_date == 'true'
+        run: echo "coinswap is already pinned to the latest commit. Nothing to do."
+
+      - name: Install Rust toolchain
+        if: steps.revs.outputs.up_to_date == 'false'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        if: steps.revs.outputs.up_to_date == 'false'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-update-coinswap-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-update-coinswap-
+
+      - name: Bump rev in Cargo.toml and refresh Cargo.lock
+        if: steps.revs.outputs.up_to_date == 'false'
+        env:
+          CURRENT: ${{ steps.revs.outputs.current }}
+          LATEST_SHORT: ${{ steps.revs.outputs.latest_short }}
+        run: |
+          set -euo pipefail
+          sed -i -E "s/(coinswap\s*=\s*\{[^}]*rev\s*=\s*\")${CURRENT}(\")/\1${LATEST_SHORT}\2/" Cargo.toml
+          grep -E '^coinswap\s*=\s*\{' Cargo.toml
+          cargo update -p coinswap
+
+      - name: Read maintainers list
+        id: maintainers
+        if: steps.revs.outputs.up_to_date == 'false'
+        run: |
+          set -euo pipefail
+          if [ ! -f .github/MAINTAINERS ]; then
+            echo "::error::.github/MAINTAINERS not found"
+            exit 1
+          fi
+          # Strip comments and blank lines, then comma-join.
+          reviewers=$(grep -vE '^\s*(#|$)' .github/MAINTAINERS | tr -d ' \t' | paste -sd, -)
+          if [ -z "$reviewers" ]; then
+            echo "::warning::.github/MAINTAINERS is empty; PR will be opened without reviewers"
+          fi
+          echo "Reviewers resolved to: $reviewers"
+          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update pull request
+        if: steps.revs.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: automated/update-coinswap
+          base: main
+          commit-message: "chore(deps): bump coinswap to ${{ steps.revs.outputs.latest_short }}"
+          title: "chore(deps): bump coinswap to ${{ steps.revs.outputs.latest_short }}"
+          body: |
+            Automated dependency update.
+
+            Bumps the `coinswap` git dependency from `${{ steps.revs.outputs.current }}` to `${{ steps.revs.outputs.latest_short }}` (upstream HEAD: `${{ steps.revs.outputs.latest }}`).
+
+            **Diff:** https://github.com/citadel-tech/coinswap/compare/${{ steps.revs.outputs.current }}...${{ steps.revs.outputs.latest_short }}
+
+            Reviewers were requested from [`.github/MAINTAINERS`](../blob/main/.github/MAINTAINERS). Let CI run on this PR to surface any breakage from the upstream changes before merging.
+
+            > If this workflow ever fails to push the PR, ensure *Settings → Actions → General → Workflow permissions* has **Allow GitHub Actions to create and approve pull requests** enabled.
+          labels: |
+            dependencies
+            automated
+            auto-update
+          reviewers: ${{ steps.maintainers.outputs.reviewers }}
+          delete-branch: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 [[package]]
 name = "coinswap"
 version = "0.2.1"
-source = "git+https://github.com/citadel-tech/coinswap#972991a671fbdfddea440ba53ac6bb9ab5b14e4b"
+source = "git+https://github.com/citadel-tech/coinswap?rev=836c2eb#836c2eb8a8d5cd8ae7a5652f429de390d51c0cd1"
 dependencies = [
  "aes-gcm",
  "bip39",
@@ -533,7 +533,8 @@ dependencies = [
  "nostr",
  "pbkdf2",
  "rust-coinselect",
- "secp256k1 0.30.0",
+ "rustls 0.23.40",
+ "secp256k1 0.32.0-beta.2",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -559,13 +560,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
+name = "cookie"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "core-foundation-sys",
- "libc",
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -700,6 +720,15 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -880,21 +909,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1643,23 +1657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
-name = "native-tls"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nostr"
 version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,50 +1721,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1885,6 +1844,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2174,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -2248,15 +2213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,12 +2254,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
-source = "git+https://github.com/jlest01/rust-secp256k1.git?branch=musig2-module#c6fc3d75033ada214bbb17d0c82c7636a72994f5"
+version = "0.32.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5fdc7d6e800869d3fd60ff857c479bf0a83ea7bf44b389e64461e844204994"
 dependencies = [
- "bitcoin_hashes",
- "rand 0.8.5",
- "secp256k1-sys 0.11.0",
+ "rand 0.9.2",
+ "secp256k1-sys 0.12.0",
 ]
 
 [[package]]
@@ -2317,33 +2273,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.11.0"
-source = "git+https://github.com/jlest01/rust-secp256k1.git?branch=musig2-module#c6fc3d75033ada214bbb17d0c82c7636a72994f5"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3be00697c88c00fe102af8dc316038cc2062eab8da646e7463f4c0e70ca9fd"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2705,6 +2639,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,11 +2894,13 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.2",
+ "rustls 0.23.40",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3017,20 +2984,34 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "flate2",
  "log",
- "once_cell",
- "rustls 0.23.37",
+ "percent-encoding",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -3051,6 +3032,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3123,12 +3110,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-coinswap = { git = "https://github.com/citadel-tech/coinswap"}
+coinswap = { git = "https://github.com/citadel-tech/coinswap", rev = "836c2eb" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_cbor = "0.11.2"
@@ -32,7 +32,7 @@ name = "api"
 path = "tests/api/mod.rs"
 
 [dev-dependencies]
-ureq = { version = "2", features = ["json"] }
+ureq = { version = "3", features = ["json"] }
 bitcoind = { version = "0.36", features = [] }
 bitcoin = { version = "0.32" }
 log = "0.4"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -199,47 +199,52 @@ struct ApiClient {
 
 impl ApiClient {
     fn new(port: u16, creds: RpcCreds) -> Self {
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(120)))
+            .http_status_as_error(false)
+            .build()
+            .into();
         Self {
             base: format!("http://127.0.0.1:{port}/api"),
-            agent: ureq::AgentBuilder::new()
-                .timeout(Duration::from_secs(120))
-                .build(),
+            agent,
             creds,
         }
     }
 
     fn get<T: DeserializeOwned>(&self, path: &str) -> T {
         self.agent
-            .get(&format!("{}{path}", self.base))
+            .get(format!("{}{path}", self.base))
             .call()
             .unwrap_or_else(|e| panic!("GET {path} failed: {e}"))
-            .into_json()
+            .into_body()
+            .read_json::<T>()
             .unwrap_or_else(|e| panic!("JSON decode GET {path}: {e}"))
     }
 
     fn post_json<T: DeserializeOwned>(&self, path: &str, body: &Value) -> T {
         self.agent
-            .post(&format!("{}{path}", self.base))
+            .post(format!("{}{path}", self.base))
             .send_json(body)
             .unwrap_or_else(|e| panic!("POST {path} failed: {e}"))
-            .into_json()
+            .into_body()
+            .read_json::<T>()
             .unwrap_or_else(|e| panic!("JSON decode POST {path}: {e}"))
     }
 
     /// Like `post_json` but returns the response body as `Value` even on non-2xx,
     /// so callers can inspect `resp["success"]` without panicking on transient errors.
     /// Only panics on transport-level failures (no connection, timeout, etc.).
+    /// Relies on the agent's `http_status_as_error(false)` config so non-2xx
+    /// responses are returned as `Ok` instead of stripped into an error.
     fn post_json_allow_status(&self, path: &str, body: &Value) -> Value {
         match self
             .agent
-            .post(&format!("{}{path}", self.base))
+            .post(format!("{}{path}", self.base))
             .send_json(body)
         {
             Ok(resp) => resp
-                .into_json()
-                .unwrap_or_else(|e| panic!("JSON decode POST {path}: {e}")),
-            Err(ureq::Error::Status(_, resp)) => resp
-                .into_json()
+                .into_body()
+                .read_json::<Value>()
                 .unwrap_or(serde_json::json!({"success": false})),
             Err(e) => panic!("POST {path} transport error: {e}"),
         }
@@ -247,10 +252,11 @@ impl ApiClient {
 
     fn put_json<T: DeserializeOwned>(&self, path: &str, body: &Value) -> T {
         self.agent
-            .put(&format!("{}{path}", self.base))
+            .put(format!("{}{path}", self.base))
             .send_json(body)
             .unwrap_or_else(|e| panic!("PUT {path} failed: {e}"))
-            .into_json()
+            .into_body()
+            .read_json::<T>()
             .unwrap_or_else(|e| panic!("JSON decode PUT {path}: {e}"))
     }
 


### PR DESCRIPTION
Automate upgrading coinswap to make it up-to-date. it detects if the current commit is the latest or not. It will open a PR to be able to check if it works without breaking anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency monitoring for the coinswap library with periodic update checks
  * Upgraded ureq library from version 2 to version 3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->