### PR TITLE
start maker on creation

### DIFF
--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -42,6 +42,10 @@ export interface SuggestedMakerPorts {
   rpc_port: number;
 }
 
+export interface MakerAutoStartSettings {
+  enabled: boolean;
+}
+
 export interface BalanceInfo {
   /** satoshis */
   regular: number;
@@ -313,6 +317,12 @@ export const makers = {
   count: (): Promise<number> => get("/makers/count"),
   suggestedPorts: (): Promise<SuggestedMakerPorts> =>
     get("/makers/ports/suggested"),
+  autoStartSettings: (): Promise<MakerAutoStartSettings> =>
+    get("/makers/auto-start"),
+  updateAutoStartSettings: (
+    enabled: boolean,
+  ): Promise<MakerAutoStartSettings> =>
+    put("/makers/auto-start", { enabled }),
   get: (id: string): Promise<MakerInfoDetailed> => get(`/makers/${id}`),
   info: (id: string): Promise<MakerInfoDetailed> => get(`/makers/${id}/info`),
   create: (body: CreateMakerRequest): Promise<MakerInfo> =>

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -321,8 +321,7 @@ export const makers = {
     get("/makers/auto-start"),
   updateAutoStartSettings: (
     enabled: boolean,
-  ): Promise<MakerAutoStartSettings> =>
-    put("/makers/auto-start", { enabled }),
+  ): Promise<MakerAutoStartSettings> => put("/makers/auto-start", { enabled }),
   get: (id: string): Promise<MakerInfoDetailed> => get(`/makers/${id}`),
   info: (id: string): Promise<MakerInfoDetailed> => get(`/makers/${id}/info`),
   create: (body: CreateMakerRequest): Promise<MakerInfo> =>

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -64,6 +64,8 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Set<string>>(new Set());
+  const [autoStartMakers, setAutoStartMakers] = useState(true);
+  const [autoStartSaving, setAutoStartSaving] = useState(false);
   const [logSwapSeenAt, setLogSwapSeenAt] = useState<Record<string, number>>(
     {},
   );
@@ -155,6 +157,16 @@ export default function Home() {
 
   useEffect(() => {
     loadMakers(true);
+    makers
+      .autoStartSettings()
+      .then((settings) => setAutoStartMakers(settings.enabled))
+      .catch((err) =>
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load maker startup setting",
+        ),
+      );
     const interval = setInterval(() => {
       void loadMakers();
     }, 15_000);
@@ -221,6 +233,24 @@ export default function Home() {
         next.delete(id);
         return next;
       });
+    }
+  }
+
+  async function toggleAutoStartMakers(enabled: boolean) {
+    setAutoStartSaving(true);
+    setAutoStartMakers(enabled);
+    try {
+      const settings = await makers.updateAutoStartSettings(enabled);
+      setAutoStartMakers(settings.enabled);
+    } catch (err) {
+      setAutoStartMakers(!enabled);
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to save maker startup setting",
+      );
+    } finally {
+      setAutoStartSaving(false);
     }
   }
 
@@ -389,12 +419,27 @@ export default function Home() {
                 </button>
               </div>
             </div>
-            <Link
-              to="/addMaker"
-              className="px-4 sm:px-5 py-2 sm:py-2.5 bg-orange-600 text-white rounded-lg hover:bg-orange-700 active:scale-[0.97] transition-all duration-150 font-semibold text-sm w-full sm:w-auto text-center"
-            >
-              + Add New Maker
-            </Link>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+              <label className="flex items-center justify-between gap-3 rounded-lg border border-gray-800 bg-gray-900 px-3 py-2 text-sm text-gray-300">
+                <span className="whitespace-nowrap">Auto-start makers</span>
+                <input
+                  type="checkbox"
+                  checked={autoStartMakers}
+                  disabled={autoStartSaving}
+                  onChange={(event) =>
+                    void toggleAutoStartMakers(event.target.checked)
+                  }
+                  className="h-4 w-4 accent-orange-600 disabled:cursor-not-allowed"
+                  aria-label="Auto-start makers on startup"
+                />
+              </label>
+              <Link
+                to="/addMaker"
+                className="px-4 sm:px-5 py-2 sm:py-2.5 bg-orange-600 text-white rounded-lg hover:bg-orange-700 active:scale-[0.97] transition-all duration-150 font-semibold text-sm w-full sm:w-auto text-center"
+              >
+                + Add New Maker
+              </Link>
+            </div>
           </div>
 
           {visibleMakerRows.length === 0 ? (

--- a/src/api/bitcoind.rs
+++ b/src/api/bitcoind.rs
@@ -29,6 +29,41 @@ fn probe_rpc(config: &MakerConfig) -> Option<String> {
     Some(info.chain.to_string())
 }
 
+/// Try well-known default RPC ports for regtest and signet.
+/// Returns the chain name on the first successful connection, or None if all fail.
+fn probe_standard_ports() -> Option<String> {
+    use coinswap::bitcoind::bitcoincore_rpc::{Auth, Client, RpcApi};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addresses = [
+        "127.0.0.1:18443", // regtest
+        "127.0.0.1:38332", // signet
+    ];
+    // Localhost-only fallback credentials; not suitable for remote hosts.
+    let auth_methods = [Auth::UserPass("user".into(), "password".into()), Auth::None];
+
+    for address in &addresses {
+        let Ok(socket_addr) = address.parse() else {
+            continue;
+        };
+        // Fast TCP check to avoid blocking on OS connect timeouts (~30 s) for
+        // ports that are not listening or behind a packet filter.
+        if TcpStream::connect_timeout(&socket_addr, Duration::from_millis(300)).is_err() {
+            continue;
+        }
+        let url = format!("http://{}", address);
+        for auth in auth_methods.clone() {
+            if let Ok(client) = Client::new(&url, auth) {
+                if let Ok(info) = client.get_blockchain_info() {
+                    return Some(info.chain.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Get bitcoind status by probing RPC connectivity via any registered maker's config.
 /// Falls back to the dashboard-managed process state if no makers are configured.
 #[utoipa::path(
@@ -56,7 +91,7 @@ async fn get_status(State(state): State<AppState>) -> Json<ApiResponse<BitcoindS
                 return Some(network);
             }
         }
-        None
+        probe_standard_ports()
     })
     .await
     .unwrap_or(None);

--- a/src/api/bitcoind.rs
+++ b/src/api/bitcoind.rs
@@ -33,7 +33,6 @@ fn probe_rpc(config: &MakerConfig) -> Option<String> {
 }
 
 /// Try well-known default RPC ports for regtest and signet.
-/// Mainnet (8332) is excluded — the UI only surfaces regtest/signet.
 /// Returns the chain name on the first successful connection, or None if all fail.
 fn probe_standard_ports() -> Option<String> {
     use coinswap::bitcoind::bitcoincore_rpc::{Auth, Client, RpcApi};

--- a/src/api/dto.rs
+++ b/src/api/dto.rs
@@ -176,6 +176,16 @@ pub struct SuggestedMakerPorts {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
+pub struct MakerAutoStartSettings {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateMakerAutoStartSettingsRequest {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum MakerStateDto {
     Running,

--- a/src/api/makers.rs
+++ b/src/api/makers.rs
@@ -208,10 +208,19 @@ async fn create_maker(
     }
 
     match mgr.create_maker(body.id.clone(), config) {
-        Ok(()) => (
-            StatusCode::CREATED,
-            Json(ApiResponse::ok(MakerInfo { id: body.id })),
-        ),
+        Ok(()) => {
+            if let Err(e) = mgr.start_maker(&body.id) {
+                tracing::warn!(
+                    "Maker '{}' created but failed to auto-start: {}",
+                    body.id,
+                    e
+                );
+            }
+            (
+                StatusCode::CREATED,
+                Json(ApiResponse::ok(MakerInfo { id: body.id })),
+            )
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiResponse::err(e.to_string())),

--- a/src/api/makers.rs
+++ b/src/api/makers.rs
@@ -11,8 +11,8 @@ use tokio::sync::Mutex;
 
 use super::{
     dto::{
-        ApiResponse, CreateMakerRequest, MakerInfo, MakerInfoDetailed, SuggestedMakerPorts,
-        UpdateMakerConfigRequest,
+        ApiResponse, CreateMakerRequest, MakerAutoStartSettings, MakerInfo, MakerInfoDetailed,
+        SuggestedMakerPorts, UpdateMakerAutoStartSettingsRequest, UpdateMakerConfigRequest,
     },
     AppState,
 };
@@ -22,6 +22,8 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/makers", get(list_makers))
         .route("/makers", post(create_maker))
+        .route("/makers/auto-start", get(get_auto_start_settings))
+        .route("/makers/auto-start", put(update_auto_start_settings))
         .route("/makers/ports/suggested", get(get_suggested_ports))
         .route("/makers/count", get(get_maker_count))
         .route("/makers/{id}", get(get_maker))
@@ -74,6 +76,50 @@ async fn get_suggested_ports(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiResponse::err(format!(
                 "Failed to suggest maker ports: {e}"
+            ))),
+        ),
+    }
+}
+
+/// Get whether makers should automatically start after restore/startup.
+#[utoipa::path(
+    get, path = "/api/makers/auto-start", tag = "makers",
+    responses((status = 200, description = "Maker auto-start setting", body = ApiResponse<MakerAutoStartSettings>))
+)]
+async fn get_auto_start_settings(
+    State(state): State<Arc<Mutex<MakerManager>>>,
+) -> Json<ApiResponse<MakerAutoStartSettings>> {
+    let mgr = state.lock().await;
+    Json(ApiResponse::ok(MakerAutoStartSettings {
+        enabled: mgr.auto_start_makers(),
+    }))
+}
+
+/// Set whether makers should automatically start after restore/startup.
+#[utoipa::path(
+    put, path = "/api/makers/auto-start", tag = "makers",
+    request_body = UpdateMakerAutoStartSettingsRequest,
+    responses(
+        (status = 200, description = "Maker auto-start setting updated", body = ApiResponse<MakerAutoStartSettings>),
+        (status = 500, description = "Internal error", body = ApiResponse<MakerAutoStartSettings>)
+    )
+)]
+async fn update_auto_start_settings(
+    State(state): State<Arc<Mutex<MakerManager>>>,
+    Json(body): Json<UpdateMakerAutoStartSettingsRequest>,
+) -> (StatusCode, Json<ApiResponse<MakerAutoStartSettings>>) {
+    let mut mgr = state.lock().await;
+    match mgr.set_auto_start_makers(body.enabled) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(ApiResponse::ok(MakerAutoStartSettings {
+                enabled: body.enabled,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiResponse::err(format!(
+                "Failed to save maker auto-start setting: {e}"
             ))),
         ),
     }
@@ -212,10 +258,26 @@ async fn create_maker(
     }
 
     match mgr.create_maker(body.id.clone(), config) {
-        Ok(()) => (
-            StatusCode::CREATED,
-            Json(ApiResponse::ok(MakerInfo { id: body.id })),
-        ),
+        Ok(()) => {
+            if mgr.auto_start_makers() {
+                if let Err(e) = mgr.start_maker(&body.id) {
+                    tracing::warn!(
+                        "Maker '{}' created but failed to auto-start: {}",
+                        body.id,
+                        e
+                    );
+                }
+            } else {
+                tracing::info!(
+                    "Maker '{}' created without auto-start because the setting is disabled",
+                    body.id
+                );
+            }
+            (
+                StatusCode::CREATED,
+                Json(ApiResponse::ok(MakerInfo { id: body.id })),
+            )
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiResponse::err(e.to_string())),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -75,6 +75,8 @@ impl FromRef<AppState> for Arc<std::path::PathBuf> {
     paths(
         makers::list_makers,
         makers::create_maker,
+        makers::get_auto_start_settings,
+        makers::update_auto_start_settings,
         makers::get_maker_count,
         makers::get_maker,
         makers::delete_maker,
@@ -112,6 +114,8 @@ impl FromRef<AppState> for Arc<std::path::PathBuf> {
         dto::UpdateMakerConfigRequest,
         dto::SendToAddressRequest,
         dto::MakerInfo,
+        dto::MakerAutoStartSettings,
+        dto::UpdateMakerAutoStartSettingsRequest,
         dto::MakerInfoDetailed,
         dto::MakerStateDto,
         dto::BalanceInfo,

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -258,8 +258,13 @@ impl MakerManager {
     }
 
     pub fn set_auto_start_makers(&mut self, enabled: bool) -> Result<()> {
+        let old = self.settings.auto_start_makers;
         self.settings.auto_start_makers = enabled;
-        self.persistence.save_settings(&self.settings)
+        if let Err(err) = self.persistence.save_settings(&self.settings) {
+            self.settings.auto_start_makers = old;
+            return Err(err);
+        }
+        Ok(())
     }
 
     /// Returns the default coinswap data directory for a maker.

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -15,7 +15,7 @@ use coinswap::maker::{MakerServer, MakerServerConfig};
 use coinswap::wallet::RPCConfig;
 use maker_pool::{MakerId, MakerPool};
 use message::{MessageRequest, MessageResponse};
-use persistence::PersistenceManager;
+use persistence::{DashboardSettings, PersistenceManager};
 
 /// Configuration for creating a new maker.
 #[derive(Debug, Clone)]
@@ -103,6 +103,7 @@ pub struct MakerManager {
     /// True iff the encryption key has been provided AND configs have been loaded.
     /// `false` between startup and login when `makers.json` exists encrypted but no key is known.
     unlocked: bool,
+    settings: DashboardSettings,
 }
 
 impl MakerManager {
@@ -121,6 +122,7 @@ impl MakerManager {
     ///   false until [`MakerManager::unlock`] is called with the AES key.
     pub fn new(config_dir: PathBuf, enc_key: Option<[u8; 32]>) -> Result<Self> {
         let persistence = PersistenceManager::new(config_dir.clone(), enc_key)?;
+        let settings = persistence.load_settings()?;
 
         let mut mgr = Self {
             pool: MakerPool::new(),
@@ -129,6 +131,7 @@ impl MakerManager {
             bitcoind_process: None,
             bitcoind_network: None,
             unlocked: false,
+            settings,
         };
 
         // Decide whether we can load now or must defer until unlock().
@@ -145,6 +148,9 @@ impl MakerManager {
         if can_load {
             let saved_configs = mgr.persistence.load()?;
             mgr.restore_makers(saved_configs);
+            if mgr.settings.auto_start_makers {
+                mgr.auto_start_restored_makers();
+            }
             mgr.unlocked = true;
         }
 
@@ -192,6 +198,20 @@ impl MakerManager {
         }
     }
 
+    fn auto_start_restored_makers(&mut self) {
+        let restored_ids: Vec<MakerId> = self.configs.keys().cloned().collect();
+        for id in restored_ids {
+            if self.pool.contains(&id) {
+                match self.pool.start_server(&id) {
+                    Ok(()) => tracing::info!("Maker '{}' auto-started after restore", id),
+                    Err(e) => {
+                        tracing::warn!("Maker '{}' restored but failed to auto-start: {}", id, e)
+                    }
+                }
+            }
+        }
+    }
+
     /// Provides the AES key and loads configs from disk if not already done.
     /// Idempotent: a second call (with the same or different key) is a no-op
     /// once the manager is already unlocked.
@@ -205,6 +225,9 @@ impl MakerManager {
         self.persistence.update_enc_key(Some(key));
         let saved_configs = self.persistence.load()?;
         self.restore_makers(saved_configs);
+        if self.settings.auto_start_makers {
+            self.auto_start_restored_makers();
+        }
         self.unlocked = true;
 
         // If makers.json doesn't exist yet (fresh setup), persist an empty
@@ -228,6 +251,15 @@ impl MakerManager {
     /// Exposed for the first-run setup handler to refuse overwriting state.
     pub fn persistence_state_file_exists(&self) -> bool {
         self.persistence.state_file_exists()
+    }
+
+    pub fn auto_start_makers(&self) -> bool {
+        self.settings.auto_start_makers
+    }
+
+    pub fn set_auto_start_makers(&mut self, enabled: bool) -> Result<()> {
+        self.settings.auto_start_makers = enabled;
+        self.persistence.save_settings(&self.settings)
     }
 
     /// Returns the default coinswap data directory for a maker.
@@ -829,6 +861,26 @@ mod tests {
         assert_ne!(network_port, 9051);
         assert_ne!(rpc_port, 9050);
         assert_ne!(rpc_port, 9051);
+    }
+
+    #[test]
+    fn auto_start_setting_persists() {
+        let config_dir = std::env::temp_dir().join(format!(
+            "maker-manager-settings-test-{}",
+            std::process::id()
+        ));
+        if config_dir.exists() {
+            std::fs::remove_dir_all(&config_dir).unwrap();
+        }
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let mut manager = MakerManager::new(config_dir.clone(), None).unwrap();
+        assert!(manager.auto_start_makers());
+
+        manager.set_auto_start_makers(false).unwrap();
+
+        let manager = MakerManager::new(config_dir, None).unwrap();
+        assert!(!manager.auto_start_makers());
     }
 }
 

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -145,6 +145,19 @@ impl MakerManager {
             mgr.persist();
         }
 
+        // Auto-start all successfully restored makers
+        let restored_ids: Vec<MakerId> = mgr.configs.keys().cloned().collect();
+        for id in restored_ids {
+            if mgr.pool.contains(&id) {
+                match mgr.pool.start_server(&id) {
+                    Ok(()) => tracing::info!("Maker '{}' auto-started on dashboard startup", id),
+                    Err(e) => {
+                        tracing::warn!("Maker '{}' restored but failed to auto-start: {}", id, e)
+                    }
+                }
+            }
+        }
+
         Ok(mgr)
     }
 

--- a/src/maker_manager/persistence.rs
+++ b/src/maker_manager/persistence.rs
@@ -145,6 +145,24 @@ struct StoredState {
     makers: HashMap<MakerId, StoredMakerConfig>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardSettings {
+    #[serde(default = "default_auto_start_makers")]
+    pub auto_start_makers: bool,
+}
+
+fn default_auto_start_makers() -> bool {
+    true
+}
+
+impl Default for DashboardSettings {
+    fn default() -> Self {
+        Self {
+            auto_start_makers: default_auto_start_makers(),
+        }
+    }
+}
+
 /// Handles persisting maker configurations to disk.
 ///
 /// This only manages the dashboard's own config (e.g. `~/.config/maker-dashboard/makers.json`).
@@ -175,10 +193,63 @@ impl PersistenceManager {
         self.config_dir.join("makers.json")
     }
 
+    fn settings_file(&self) -> PathBuf {
+        self.config_dir.join("settings.json")
+    }
+
     /// Returns true if `makers.json` already exists on disk.
     /// Used by the first-run setup handler to refuse overwriting existing state.
     pub fn state_file_exists(&self) -> bool {
         self.state_file().exists()
+    }
+
+    pub fn load_settings(&self) -> Result<DashboardSettings> {
+        let path = self.settings_file();
+        if !path.exists() {
+            return Ok(DashboardSettings::default());
+        }
+
+        let raw = fs::read(&path)
+            .with_context(|| format!("Failed to read settings file: {}", path.display()))?;
+        serde_json::from_slice(&raw)
+            .with_context(|| format!("Failed to parse settings file: {}", path.display()))
+    }
+
+    pub fn save_settings(&self, settings: &DashboardSettings) -> Result<()> {
+        let payload =
+            serde_json::to_vec_pretty(settings).context("Failed to serialize settings")?;
+        let path = self.settings_file();
+        let tmp_path = path.with_extension("tmp");
+
+        let _ = fs::remove_file(&tmp_path);
+        {
+            use std::io::Write as _;
+            let mut opts = fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut file = opts.open(&tmp_path).with_context(|| {
+                format!("Failed to open temp settings file: {}", tmp_path.display())
+            })?;
+            file.write_all(&payload)
+                .with_context(|| format!("Failed to write settings file: {}", path.display()))?;
+            file.sync_all().with_context(|| {
+                format!("Failed to fsync settings file: {}", tmp_path.display())
+            })?;
+        }
+
+        fs::rename(&tmp_path, &path).with_context(|| {
+            format!(
+                "Failed to atomically rename {} -> {}",
+                tmp_path.display(),
+                path.display()
+            )
+        })?;
+
+        Ok(())
     }
 
     /// Saves all maker configs to disk

--- a/tests/api/makers.rs
+++ b/tests/api/makers.rs
@@ -68,6 +68,40 @@ async fn suggested_ports_skip_taken_defaults() {
 }
 
 #[tokio::test]
+async fn auto_start_setting_defaults_to_enabled() {
+    let (status, body) = get(test_app(), "/makers/auto-start").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body,
+        json!({ "success": true, "data": { "enabled": true } })
+    );
+}
+
+#[tokio::test]
+async fn auto_start_setting_can_be_updated() {
+    let app = test_app();
+
+    let (put_status, put_body) = put(
+        app.clone(),
+        "/makers/auto-start",
+        json!({ "enabled": false }),
+    )
+    .await;
+    assert_eq!(put_status, StatusCode::OK);
+    assert_eq!(
+        put_body,
+        json!({ "success": true, "data": { "enabled": false } })
+    );
+
+    let (get_status, get_body) = get(app, "/makers/auto-start").await;
+    assert_eq!(get_status, StatusCode::OK);
+    assert_eq!(
+        get_body,
+        json!({ "success": true, "data": { "enabled": false } })
+    );
+}
+
+#[tokio::test]
 async fn list_and_count_stay_empty_after_failed_create() {
     let app = test_app();
     // This fails because there is no Bitcoin node at 127.0.0.1:19998

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -433,6 +433,27 @@ impl ApiClient {
         )
     }
 
+    fn get_dashboard_auto_start(&self) -> bool {
+        let resp: Value = self.get("/makers/auto-start");
+        assert!(
+            resp["success"].as_bool().unwrap_or(false),
+            "get auto-start setting failed: {resp}"
+        );
+        resp["data"]["enabled"].as_bool().unwrap_or(false)
+    }
+
+    fn set_dashboard_auto_start(&self, enabled: bool) {
+        let resp: Value = self.put_json(
+            "/makers/auto-start",
+            &serde_json::json!({ "enabled": enabled }),
+        );
+        assert!(
+            resp["success"].as_bool().unwrap_or(false),
+            "set auto-start setting failed: {resp}"
+        );
+        assert_eq!(resp["data"]["enabled"].as_bool(), Some(enabled));
+    }
+
     fn health(&self) -> Value {
         self.get("/health")
     }
@@ -560,6 +581,9 @@ fn test_maker_manager_integration() {
     let health: Value = client.health();
     assert_eq!(health["data"]["status"].as_str(), Some("ok"));
 
+    client.set_dashboard_auto_start(true);
+    assert!(client.get_dashboard_auto_start());
+
     // Create two makers
     println!("[INFO] Creating makers");
     client.create_maker(
@@ -647,11 +671,7 @@ fn test_maker_manager_integration() {
     generate_blocks(&bitcoind, 1);
     taker.get_wallet().write().unwrap().sync_and_save().unwrap();
 
-    // Start both makers and wait for their coinswap servers to be ready
-    println!("[INFO] Starting makers");
-    client.start_maker(MAKER_ALPHA_ID);
-    client.start_maker(MAKER_BETA_ID);
-
+    // Makers were auto-started on creation; wait for their coinswap servers to be ready.
     // Start a continuous block generator. Makers broadcast fidelity bonds and
     // settlement transactions asynchronously and then enter an internal sync
     // loop that holds the wallet write lock with growing backoff (10s, 20s,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -617,11 +617,7 @@ fn test_maker_manager_integration() {
     generate_blocks(&bitcoind, 1);
     taker.get_wallet().write().unwrap().sync_and_save().unwrap();
 
-    // Start both makers and wait for their coinswap servers to be ready
-    println!("[INFO] Starting makers");
-    client.start_maker(MAKER_ALPHA_ID);
-    client.start_maker(MAKER_BETA_ID);
-
+    // Makers were auto-started on creation; wait for their coinswap servers to be ready.
     // Start a continuous block generator. Makers broadcast fidelity bonds and
     // settlement transactions asynchronously and then enter an internal sync
     // loop that holds the wallet write lock with growing backoff (10s, 20s,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Makers auto-start on creation; creation still returns success if auto-start fails (warning logged).
  * Previously saved makers are auto-restarted when the dashboard launches.
  * Dashboard now exposes a persistent "Auto-start makers" setting with UI toggle and API endpoints to view/update it.
  * Improved node-status probing with a fallback scan of standard local node ports.

* **Tests**
  * Integration tests updated to assume makers are auto-started on creation and cover the auto-start setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/maker-dashboard/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->