### PR TITLE
Fix: auth setup when maker state already exists

### DIFF
--- a/frontend/app/routes/setup.tsx
+++ b/frontend/app/routes/setup.tsx
@@ -69,13 +69,17 @@ export default function Setup() {
       if (err instanceof ApiError) {
         switch (err.status) {
           case 409:
-            setError(
-              "Dashboard is already initialized. Use the login page instead.",
-            );
-            setTimeout(() => navigate("/login"), 1500);
+            if (err.message.includes("already initialized")) {
+              setError(
+                "Dashboard is already initialized. Use the login page instead.",
+              );
+              setTimeout(() => navigate("/login"), 1500);
+            } else {
+              setError(err.message);
+            }
             break;
           case 400:
-            setError("Password must not be empty.");
+            setError(err.message);
             break;
           default:
             setError("Setup failed. Please try again.");

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -156,8 +156,15 @@ async fn setup(
             .into_response();
     }
 
-    // Refuse to overwrite an existing makers.json (loss-of-data guard).
-    if makers.lock().await.persistence_state_file_exists() {
+    // Refuse to overwrite encrypted state that is present but not loaded. If
+    // the manager is already unlocked, the state is either fresh/empty or a
+    // legacy plaintext file that has been loaded and can be re-saved with the
+    // setup password below.
+    let maker_state_is_locked = {
+        let makers = makers.lock().await;
+        makers.persistence_state_file_exists() && !makers.is_unlocked()
+    };
+    if maker_state_is_locked {
         return (
             StatusCode::CONFLICT,
             Json(ApiResponse::<()>::err(
@@ -203,8 +210,19 @@ async fn setup(
             .into_response();
     }
 
-    // Unlock the maker manager (this also persists an empty makers.json).
-    if let Err(e) = makers.lock().await.unlock(key) {
+    // Initialize maker persistence with the setup key. On a true first run the
+    // manager may already be unlocked with no key, so rotate_enc_key() is the
+    // path that writes the first encrypted makers.json. It also migrates loaded
+    // legacy plaintext state without dropping existing makers.
+    let maker_init_result = {
+        let mut makers = makers.lock().await;
+        if makers.is_unlocked() {
+            makers.rotate_enc_key(Some(key))
+        } else {
+            makers.unlock(key)
+        }
+    };
+    if let Err(e) = maker_init_result {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiResponse::<()>::err(format!(

--- a/tests/api/auth.rs
+++ b/tests/api/auth.rs
@@ -1,0 +1,89 @@
+//! Tests for dashboard authentication and first-run setup.
+
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::Router;
+use serde_json::json;
+use tokio::sync::Mutex;
+
+use maker_dashboard::{
+    api::{api_router, AppState},
+    auth::SessionStore,
+    maker_manager::MakerManager,
+};
+
+use super::{get, post, temp_config_dir};
+
+fn setup_app(config_dir: std::path::PathBuf) -> Router {
+    let manager = MakerManager::new(config_dir.clone(), None).expect("MakerManager::new");
+    let state = AppState {
+        makers: Arc::new(Mutex::new(manager)),
+        sessions: Arc::new(Mutex::new(SessionStore::new())),
+        auth: Arc::new(std::sync::RwLock::new(None)),
+        setup_lock: Arc::new(Mutex::new(())),
+        config_dir: Arc::new(config_dir),
+    };
+    api_router().with_state(state)
+}
+
+#[tokio::test]
+async fn setup_initializes_fresh_dashboard_and_persists_encrypted_state() {
+    let config_dir = temp_config_dir();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let app = setup_app(config_dir.clone());
+
+    let (status, body) = post(
+        app.clone(),
+        "/auth/setup",
+        json!({ "password": "test-password" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!({ "success": true, "data": null }));
+
+    let (status, body) = get(app, "/auth/status").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["password_exists"], true);
+
+    let makers = std::fs::read_to_string(config_dir.join("makers.json")).unwrap();
+    let makers: serde_json::Value = serde_json::from_str(&makers).unwrap();
+    assert_eq!(makers["v"], 1);
+    assert!(makers["data"].is_string());
+}
+
+#[tokio::test]
+async fn setup_migrates_loaded_legacy_plaintext_maker_state() {
+    let config_dir = temp_config_dir();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("makers.json"), r#"{"makers":{}}"#).unwrap();
+    let app = setup_app(config_dir.clone());
+
+    let (status, body) = post(app, "/auth/setup", json!({ "password": "test-password" })).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!({ "success": true, "data": null }));
+
+    let makers = std::fs::read_to_string(config_dir.join("makers.json")).unwrap();
+    let makers: serde_json::Value = serde_json::from_str(&makers).unwrap();
+    assert_eq!(makers["v"], 1);
+    assert!(makers["data"].is_string());
+}
+
+#[tokio::test]
+async fn setup_refuses_locked_maker_state_without_auth_config() {
+    let config_dir = temp_config_dir();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("makers.json"), r#"{"v":1,"data":"AA=="}"#).unwrap();
+    let app = setup_app(config_dir);
+
+    let (status, body) = post(app, "/auth/setup", json!({ "password": "test-password" })).await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["success"], false);
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("makers.json already exists"));
+}

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -23,6 +23,7 @@ use maker_dashboard::{
     maker_manager::MakerManager,
 };
 
+mod auth;
 mod fidelity;
 mod makers;
 mod monitoring;
@@ -36,9 +37,7 @@ static COUNTER: AtomicU64 = AtomicU64::new(0);
 /// is derived, and `MakerManager::unlock` is called so handlers see an
 /// initialized + unlocked dashboard.
 pub fn test_app() -> Router {
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let config_dir =
-        std::env::temp_dir().join(format!("maker-api-test-{}-{}", std::process::id(), n));
+    let config_dir = temp_config_dir();
     if config_dir.exists() {
         std::fs::remove_dir_all(&config_dir).unwrap();
     }
@@ -58,6 +57,11 @@ pub fn test_app() -> Router {
         config_dir: Arc::new(config_dir),
     };
     api_router().with_state(state)
+}
+
+pub fn temp_config_dir() -> std::path::PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("maker-api-test-{}-{}", std::process::id(), n))
 }
 
 /// GET request => (status, response JSON).


### PR DESCRIPTION
Fixes #93 

## Changes
- Allow first-run setup to proceed when existing maker state is already loaded and can be safely encrypted with the new dashboard password.
- Preserve the data-loss guard for locked encrypted `makers.json` state without a matching auth config.
- Update setup-page error handling so only the real “already initialized” conflict redirects to login.
- Add API tests for fresh setup, legacy maker-state migration, and locked maker-state refusal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging during dashboard setup with clearer distinction of initialization states
  * Added automatic redirect to login when dashboard is already initialized
  * Enhanced initialization state detection to prevent conflicts during setup operations

* **Tests**
  * Added comprehensive integration tests for authentication and setup workflows
  * Added test coverage for data migration scenarios and conflict handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/maker-dashboard/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->