### PR TITLE
docs: add libtor-src build dependencies for macOS and Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,19 @@ Maker Dashboard is a full-stack application for managing Coinswap maker nodes. T
 
 ## Commands
 
+The backend builds bundled Tor through `libtor-src`. Before running Rust build
+commands, macOS needs:
+
+```sh
+brew install automake autoconf libtool pkg-config openssl
+```
+
+Windows needs MSYS2 with `C:\msys64\usr\bin` on `PATH` and these packages:
+
+```sh
+pacman -S --needed autoconf automake libtool patch make
+```
+
 ### Backend
 ```sh
 cargo build --release          # build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ Before diving in, read [docs/ARCH.md](docs/ARCH.md) to understand how the codeba
 
 You need Rust (stable) and Node.js (LTS or later).
 
+The backend builds bundled Tor through `libtor-src`, so install the native build
+tools for your platform before running `cargo build`:
+
+```sh
+# macOS
+brew install automake autoconf libtool pkg-config openssl
+```
+
+On Windows, install the MSYS2 toolchain and add `C:\msys64\usr\bin` to your
+`PATH`:
+
+```sh
+# Windows, from an MSYS2 shell
+pacman -S --needed autoconf automake libtool patch make
+```
+
 ```sh
 git clone https://github.com/citadel-tech/maker-dashboard
 cd maker-dashboard

--- a/README.md
+++ b/README.md
@@ -35,9 +35,29 @@ For protocol background, see the [Coinswap documentation](https://github.com/cit
 - **RPC enabled** on your Bitcoin node
 - **REST enabled** on your Bitcoin node (`rest=1`)
 - **ZMQ enabled** on your Bitcoin node for real-time block and transaction updates
-- A local **Tor** daemon with SOCKS and control ports reachable by the maker
 - **Rust** and `cargo` for the backend
 - **Node.js** and `npm` for the frontend
+- Native build tools required by the bundled Tor build (`libtor-src`)
+
+Install the platform-specific native build tools before running `cargo build` or
+`make build`:
+
+```sh
+# macOS
+brew install automake autoconf libtool pkg-config openssl
+```
+
+On Windows, install the MSYS2 toolchain and add `C:\msys64\usr\bin` to your
+`PATH`:
+
+```sh
+# Windows, from an MSYS2 shell
+pacman -S --needed autoconf automake libtool patch make
+```
+
+The dashboard deploys Tor automatically through `libtor-src`. If you configure a
+maker to use an external Tor instance instead, that Tor daemon must expose SOCKS
+and control ports reachable by the maker.
 
 Typical local defaults used by the onboarding checks:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisite instructions with platform-specific native build tool requirements for macOS and Windows
  * Clarified Tor deployment behavior and external Tor port configuration  
  * Enhanced development setup guidance for bundled Tor builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/maker-dashboard/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->