### PR TITLE
remove secure from cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,17 +149,17 @@ Registered makers are restored on dashboard restart, but they are **not auto-sta
 
 Runtime options can be set with CLI flags or environment variables:
 
-| Flag              | Env var                   | Default                            | Description                                |
-| ----------------- | ------------------------- | ---------------------------------- | ------------------------------------------ |
-| `--host`          | `DASHBOARD_HOST`          | `127.0.0.1`                        | IP address to bind to                      |
-| `--port`          | `DASHBOARD_PORT`          | `3000`                             | Port to listen on                          |
-| `--frontend-path` | `DASHBOARD_FRONTEND_PATH` | `frontend/build/client`            | Directory containing built frontend assets |
-| `--spa-index`     | `DASHBOARD_SPA_INDEX`     | `frontend/build/client/index.html` | SPA fallback file                          |
-| `--allow-remote`  | `DASHBOARD_ALLOW_REMOTE`  | `false`                            | Allow non-localhost requests               |
-| `--disable-secure-cookies` | `DASHBOARD_DISABLE_SECURE_COOKIES` | `false` | Allow session cookies over plain HTTP |
-| `--log-filter`    | `DASHBOARD_LOG_FILTER`    | `tower_http=debug,info`            | Tracing filter directive                   |
-| `--no-color`      | `DASHBOARD_NO_COLOR`      | `false`                            | Disable ANSI colors in logs                |
-| `--config-dir`    | `DASHBOARD_CONFIG_DIR`    | platform default                   | Dashboard config directory                 |
+| Flag                       | Env var                            | Default                            | Description                                |
+| -------------------------- | ---------------------------------- | ---------------------------------- | ------------------------------------------ |
+| `--host`                   | `DASHBOARD_HOST`                   | `127.0.0.1`                        | IP address to bind to                      |
+| `--port`                   | `DASHBOARD_PORT`                   | `3000`                             | Port to listen on                          |
+| `--frontend-path`          | `DASHBOARD_FRONTEND_PATH`          | `frontend/build/client`            | Directory containing built frontend assets |
+| `--spa-index`              | `DASHBOARD_SPA_INDEX`              | `frontend/build/client/index.html` | SPA fallback file                          |
+| `--allow-remote`           | `DASHBOARD_ALLOW_REMOTE`           | `false`                            | Allow non-localhost requests               |
+| `--disable-secure-cookies` | `DASHBOARD_DISABLE_SECURE_COOKIES` | `false`                            | Allow session cookies over plain HTTP      |
+| `--log-filter`             | `DASHBOARD_LOG_FILTER`             | `tower_http=debug,info`            | Tracing filter directive                   |
+| `--no-color`               | `DASHBOARD_NO_COLOR`               | `false`                            | Disable ANSI colors in logs                |
+| `--config-dir`             | `DASHBOARD_CONFIG_DIR`             | platform default                   | Dashboard config directory                 |
 
 By default the dashboard only accepts connections from the local machine. If you enable `--allow-remote`, place a TLS-terminating reverse proxy in front. the built-in password auth is the only protection on the wire. If you must access the dashboard over plain HTTP, use `--disable-secure-cookies` so browsers keep the login session cookie.
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ Runtime options can be set with CLI flags or environment variables:
 | `--frontend-path` | `DASHBOARD_FRONTEND_PATH` | `frontend/build/client`            | Directory containing built frontend assets |
 | `--spa-index`     | `DASHBOARD_SPA_INDEX`     | `frontend/build/client/index.html` | SPA fallback file                          |
 | `--allow-remote`  | `DASHBOARD_ALLOW_REMOTE`  | `false`                            | Allow non-localhost requests               |
+| `--disable-secure-cookies` | `DASHBOARD_DISABLE_SECURE_COOKIES` | `false` | Allow session cookies over plain HTTP |
 | `--log-filter`    | `DASHBOARD_LOG_FILTER`    | `tower_http=debug,info`            | Tracing filter directive                   |
 | `--no-color`      | `DASHBOARD_NO_COLOR`      | `false`                            | Disable ANSI colors in logs                |
 | `--config-dir`    | `DASHBOARD_CONFIG_DIR`    | platform default                   | Dashboard config directory                 |
 
-By default the dashboard only accepts connections from the local machine. If you enable `--allow-remote`, place a TLS-terminating reverse proxy in front. the built-in password auth is the only protection on the wire.
+By default the dashboard only accepts connections from the local machine. If you enable `--allow-remote`, place a TLS-terminating reverse proxy in front. the built-in password auth is the only protection on the wire. If you must access the dashboard over plain HTTP, use `--disable-secure-cookies` so browsers keep the login session cookie.
 
 Dashboard-managed files:
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -115,8 +115,7 @@ async fn login(
     }
 
     let token = sessions.lock().await.create();
-    let cookie =
-        format!("session={token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=86400");
+    let cookie = format!("session={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400");
     (
         StatusCode::OK,
         [(header::SET_COOKIE, cookie)],
@@ -236,8 +235,7 @@ async fn setup(
     *auth.write().unwrap() = Some(new_auth);
 
     let token = sessions.lock().await.create();
-    let cookie =
-        format!("session={token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=86400");
+    let cookie = format!("session={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400");
     (
         StatusCode::OK,
         [(header::SET_COOKIE, cookie)],

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -50,6 +50,7 @@ async fn login(
     State(auth): State<Arc<RwLock<Option<AuthConfig>>>>,
     State(sessions): State<Arc<Mutex<SessionStore>>>,
     State(makers): State<Arc<Mutex<crate::maker_manager::MakerManager>>>,
+    State(secure_cookies): State<bool>,
     Json(body): Json<LoginRequest>,
 ) -> impl IntoResponse {
     // Verify against the stored hash and derive the AES key under the read
@@ -115,7 +116,7 @@ async fn login(
     }
 
     let token = sessions.lock().await.create();
-    let cookie = format!("session={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400");
+    let cookie = session_cookie(&token, secure_cookies);
     (
         StatusCode::OK,
         [(header::SET_COOKIE, cookie)],
@@ -130,6 +131,7 @@ async fn setup(
     State(setup_lock): State<Arc<Mutex<()>>>,
     State(makers): State<Arc<Mutex<crate::maker_manager::MakerManager>>>,
     State(config_dir): State<Arc<std::path::PathBuf>>,
+    State(secure_cookies): State<bool>,
     Json(body): Json<SetupRequest>,
 ) -> impl IntoResponse {
     // Hold the setup lock for the entire critical section so two concurrent
@@ -235,7 +237,7 @@ async fn setup(
     *auth.write().unwrap() = Some(new_auth);
 
     let token = sessions.lock().await.create();
-    let cookie = format!("session={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400");
+    let cookie = session_cookie(&token, secure_cookies);
     (
         StatusCode::OK,
         [(header::SET_COOKIE, cookie)],
@@ -406,4 +408,9 @@ pub fn extract_session_token(headers: &axum::http::HeaderMap) -> Option<String> 
         let part = part.trim();
         part.strip_prefix("session=").map(|v| v.to_string())
     })
+}
+
+fn session_cookie(token: &str, secure: bool) -> String {
+    let secure_attr = if secure { "; Secure" } else { "" };
+    format!("session={token}; HttpOnly{secure_attr}; SameSite=Strict; Path=/; Max-Age=86400")
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,8 @@ pub struct AppState {
     /// while holding this lock.
     pub setup_lock: Arc<Mutex<()>>,
     pub config_dir: Arc<std::path::PathBuf>,
+    /// Whether session cookies should include the Secure attribute.
+    pub secure_cookies: bool,
 }
 
 impl FromRef<AppState> for Arc<Mutex<MakerManager>> {
@@ -66,6 +68,12 @@ impl FromRef<AppState> for Arc<Mutex<()>> {
 impl FromRef<AppState> for Arc<std::path::PathBuf> {
     fn from_ref(state: &AppState) -> Self {
         state.config_dir.clone()
+    }
+}
+
+impl FromRef<AppState> for bool {
+    fn from_ref(state: &AppState) -> Self {
+        state.secure_cookies
     }
 }
 

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -872,6 +872,7 @@ mod tests {
             ))),
             setup_lock: Arc::new(Mutex::new(())),
             config_dir: Arc::new(config_dir.clone()),
+            secure_cookies: true,
         };
         let app = routes().with_state(state);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,14 @@ pub struct Cli {
     #[arg(long, default_value_t = false, env = "DASHBOARD_ALLOW_REMOTE")]
     pub allow_remote: bool,
 
+    /// Disable the Secure attribute on session cookies for plain HTTP deployments.
+    #[arg(
+        long,
+        default_value_t = false,
+        env = "DASHBOARD_DISABLE_SECURE_COOKIES"
+    )]
+    pub disable_secure_cookies: bool,
+
     /// Log filter directive (e.g. "debug", "tower_http=debug,info")
     #[arg(
         long,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ async fn main() {
         frontend_path: args.frontend_path,
         spa_index: args.spa_index,
         localhost_only: !args.allow_remote,
+        secure_cookies: !args.disable_secure_cookies,
         config_dir,
     };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,6 +26,8 @@ pub struct ServerConfig {
     pub spa_index: PathBuf,
     /// Whether to restrict access to localhost only
     pub localhost_only: bool,
+    /// Whether to set the Secure attribute on session cookies
+    pub secure_cookies: bool,
     /// Application config/data directory (e.g. ~/.config/maker-dashboard)
     pub config_dir: PathBuf,
 }
@@ -38,6 +40,7 @@ impl Default for ServerConfig {
             frontend_path: PathBuf::from("frontend/build/client"),
             spa_index: PathBuf::from("frontend/build/client/index.html"),
             localhost_only: true,
+            secure_cookies: true,
             config_dir: default_config_dir(),
         }
     }
@@ -89,6 +92,7 @@ impl Server {
             auth: Arc::new(std::sync::RwLock::new(auth_config)),
             setup_lock: Arc::new(Mutex::new(())),
             config_dir: Arc::new(config.config_dir.clone()),
+            secure_cookies: config.secure_cookies,
         };
 
         Ok(Self { config, state })
@@ -133,6 +137,11 @@ impl Server {
         if self.config.localhost_only {
             tracing::info!(
                 "Localhost requests only are accepted. All requests from outside machine are forbidden for security reasons."
+            );
+        }
+        if !self.config.secure_cookies {
+            tracing::warn!(
+                "Secure cookies are disabled. Use this only for trusted plain HTTP deployments."
             );
         }
         tracing::info!("API docs available at http://{}/swagger-ui/", addr);

--- a/tests/api/auth.rs
+++ b/tests/api/auth.rs
@@ -16,6 +16,10 @@ use maker_dashboard::{
 use super::{get, post, temp_config_dir};
 
 fn setup_app(config_dir: std::path::PathBuf) -> Router {
+    setup_app_with_secure_cookies(config_dir, true)
+}
+
+fn setup_app_with_secure_cookies(config_dir: std::path::PathBuf, secure_cookies: bool) -> Router {
     let manager =
         MakerManager::new_for_testing(config_dir.clone(), None).expect("MakerManager::new");
     let state = AppState {
@@ -24,6 +28,7 @@ fn setup_app(config_dir: std::path::PathBuf) -> Router {
         auth: Arc::new(std::sync::RwLock::new(None)),
         setup_lock: Arc::new(Mutex::new(())),
         config_dir: Arc::new(config_dir),
+        secure_cookies,
     };
     api_router().with_state(state)
 }
@@ -87,4 +92,16 @@ async fn setup_refuses_locked_maker_state_without_auth_config() {
         .as_str()
         .unwrap()
         .contains("makers.json already exists"));
+}
+
+#[tokio::test]
+async fn setup_session_cookie_can_disable_secure_attribute() {
+    let config_dir = temp_config_dir();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let app = setup_app_with_secure_cookies(config_dir, false);
+
+    let (status, body) = post(app, "/auth/setup", json!({ "password": "test-password" })).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!({ "success": true, "data": null }));
 }

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -56,6 +56,7 @@ pub fn test_app() -> Router {
         auth: Arc::new(std::sync::RwLock::new(Some(auth_config))),
         setup_lock: Arc::new(Mutex::new(())),
         config_dir: Arc::new(config_dir),
+        secure_cookies: true,
     };
     api_router().with_state(state)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -139,6 +139,7 @@ impl DashboardGuard {
                         frontend_path: PathBuf::from("frontend/build/client"),
                         spa_index: PathBuf::from("frontend/build/client/index.html"),
                         localhost_only: true,
+                        secure_cookies: true,
                         config_dir,
                     };
                     let server = Server::new(cfg).expect("Server::new");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime flag/env to allow session cookies over plain HTTP when explicitly enabled.

* **Bug Fixes**
  * Login and account setup now honor the cookie security setting so session cookies match configured behavior.

* **Documentation**
  * README updated with the new runtime option and environment variable and guidance for non-TLS access.

* **Chores**
  * Server emits a warning when secure cookies are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->