### PR TITLE
refactor: make `--allow-remote` is enabled by default

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test container starts and responds
         run: |
           docker run -d --name test-container -p 3000:3000 \
-            -e DASHBOARD_HOST=0.0.0.0 -e DASHBOARD_ALLOW_REMOTE=true \
+            -e DASHBOARD_HOST=0.0.0.0 \
             maker-dashboard:test
           # Wait for the server to be ready
           for i in $(seq 1 30); do

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ docker-build:
 	docker build -t maker-dashboard .
 
 docker-run:
-	docker run -p 3000:3000 -e DASHBOARD_HOST=0.0.0.0 -e DASHBOARD_ALLOW_REMOTE=true maker-dashboard
+	docker run -p 3000:3000 -e DASHBOARD_HOST=0.0.0.0 -e maker-dashboard
 
 help:
 	@echo "Maker Dashboard - Available commands:"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,13 +48,11 @@ logins; no restart or env-var update is required.
 
 ## Localhost-only access
 
-By default the dashboard binds to `127.0.0.1` and a middleware rejects every request
+When you are using `--allow-remote=false`, the dashboard would bind to `127.0.0.1` and a middleware rejects every request
 whose source IP is not a loopback address, providing defence-in-depth on top of the
-password layer.
+password layer. But by default, it allows non-Localhost requests without issues. This is an additional security layer if you want.
 
-This restriction is lifted when you set `--allow-remote` or `DASHBOARD_ALLOW_REMOTE=true`.
-When running remotely, place the dashboard behind a reverse proxy that enforces TLS
-before forwarding to it, so the session cookie and password are never sent in cleartext.
+You may be able to access the dashboard if you use this option and run it inside a docker container. You will need to run it on the host network and may face a lot of issues with non-linux systems like [MacOS](https://forums.docker.com/t/enabling-network-host-on-macos/150379).
 
 ## Hot wallet
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,6 @@ services:
     environment:
       - DASHBOARD_HOST=0.0.0.0
       - DASHBOARD_PORT=${DASHBOARD_PORT:-3000}
-      - DASHBOARD_ALLOW_REMOTE=true
       - DASHBOARD_LOG_FILTER=${DASHBOARD_LOG_FILTER:-tower_http=debug,info}
       - DASHBOARD_NO_COLOR=true
     restart: unless-stopped

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -124,6 +124,4 @@ Every endpoint returns the same JSON envelope:
 { "success": false, "error": "<message>" }
 ```
 
-Authentication is handled at the network level. By default the server binds to `127.0.0.1` and a middleware rejects any request that did not originate from localhost. Remote access can be enabled with `--allow-remote` / `DASHBOARD_ALLOW_REMOTE=true`, but there is no built-in login system. securing that is the operator's responsibility (e.g. via a reverse proxy with TLS and authentication in front of the dashboard).
-
 Interactive OpenAPI documentation for all endpoints is available at `http://localhost:3000/swagger-ui/` while the server is running.

--- a/packaging/umbrel/docker-compose.yml
+++ b/packaging/umbrel/docker-compose.yml
@@ -29,4 +29,3 @@ services:
     environment:
       DASHBOARD_HOST: 0.0.0.0
       DASHBOARD_PORT: "3000"
-      DASHBOARD_ALLOW_REMOTE: "true"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,8 +36,8 @@ pub struct Cli {
     )]
     pub spa_index: PathBuf,
 
-    /// Allow requests from non-localhost addresses (disabled by default for security)
-    #[arg(long, default_value_t = false, env = "DASHBOARD_ALLOW_REMOTE")]
+    /// Allow requests from non-localhost addresses (enabled by default for security)
+    #[arg(long, default_value_t = true, env = "DASHBOARD_ALLOW_REMOTE")]
     pub allow_remote: bool,
 
     /// Log filter directive (e.g. "debug", "tower_http=debug,info")


### PR DESCRIPTION
Banning non-localhost requests by default causes a lot of issues. should be optional since the authentication is added