### PR TITLE
Add dashboard password change entrypoint and fix validation message

### DIFF
--- a/frontend/app/components/Nav.tsx
+++ b/frontend/app/components/Nav.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import { auth, ApiError } from "@/api";
 
+const MIN_PASSWORD_LENGTH = 8;
+
 function PasswordInput({
   value,
   onChange,
@@ -57,6 +59,10 @@ export function ChangePasswordModal({ onClose }: { onClose: () => void }) {
       setError("New passwords do not match");
       return;
     }
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
     setLoading(true);
     try {
       await auth.rotatePassword(oldPassword, newPassword);
@@ -65,7 +71,7 @@ export function ChangePasswordModal({ onClose }: { onClose: () => void }) {
       if (err instanceof ApiError && err.status === 401) {
         setError("Current password is incorrect");
       } else if (err instanceof ApiError && err.status === 400) {
-        setError("New password must differ from the current password");
+        setError(err.message);
       } else {
         setError("Failed to change password. Please try again.");
       }

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { ArrowDown, Check, Copy, Plus, X, Zap } from "lucide-react";
 import OnboardingWizard from "./onboarding";
 import BitcoindWidget from "../components/BitcoindWidget";
+import { ChangePasswordModal } from "../components/Nav";
 import {
   makers,
   wallet,
@@ -63,6 +64,7 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
   const [copiedTor, setCopiedTor] = useState<string | null>(null);
   const [swapBannerDismissed, setSwapBannerDismissed] = useState(false);
+  const [showChangePassword, setShowChangePassword] = useState(false);
   const swapHistoryCache = useRef<Record<string, UtxoInfo[]>>({});
   const swapReportCache = useRef<Record<string, SwapReportDto[]>>({});
   const lastSwapRefreshAt = useRef(0);
@@ -312,10 +314,19 @@ export default function Home() {
                 </button>
               </div>
             </div>
-            <Link to="/addMaker" className="cs-btn primary">
-              <Plus size={15} />
-              Add new maker
-            </Link>
+            <div className="cs-actions">
+              <button
+                type="button"
+                onClick={() => setShowChangePassword(true)}
+                className="cs-btn primary"
+              >
+                Change password
+              </button>
+              <Link to="/addMaker" className="cs-btn primary">
+                <Plus size={15} />
+                Add new maker
+              </Link>
+            </div>
           </div>
 
           {visibleMakerRows.length === 0 ? (
@@ -474,6 +485,9 @@ export default function Home() {
           </div>
         </section>
       </main>
+      {showChangePassword && (
+        <ChangePasswordModal onClose={() => setShowChangePassword(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Adds a visible Change password button beside `+ Add new maker` on the dashboard, reusing the existing model.
Also fixes password validation feedback so short passwords show the correct minimum-length error instead of being reported as matching the old password.

<img width="1903" height="972" alt="image" src="https://github.com/user-attachments/assets/d0ffa010-6303-4bd3-ac86-c0672a7e2d4a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now change their password directly from the home page via a new "Change Password" option in the header.

* **Bug Fixes**
  * Added password length validation for password changes.
  * Improved error messaging to provide clearer feedback when password change attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->