### PR TITLE
fix: Retry maker auto-start after dashboard bitcoind start

### DIFF
--- a/frontend/app/components/BitcoindWidget.tsx
+++ b/frontend/app/components/BitcoindWidget.tsx
@@ -20,7 +20,15 @@ const NETWORK_DEFAULTS: Record<
   },
 };
 
-export default function BitcoindWidget() {
+const MAKER_REFRESH_DELAY_MS = 7_000;
+
+interface BitcoindWidgetProps {
+  onStatusChange?: () => void;
+}
+
+export default function BitcoindWidget({
+  onStatusChange,
+}: BitcoindWidgetProps) {
   const [status, setStatus] = useState<BitcoindStatusInfo>({
     running: false,
     managed: false,
@@ -90,7 +98,9 @@ export default function BitcoindWidget() {
       } else {
         const s = await bitcoind.start({ network });
         setStatus(s);
+        window.setTimeout(() => onStatusChange?.(), MAKER_REFRESH_DELAY_MS);
       }
+      onStatusChange?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Action failed");
     } finally {

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -356,7 +356,7 @@ export default function Home() {
                 {reportsPartial ? " · partial" : ""}
               </span>
             </article>
-            <BitcoindWidget />
+            <BitcoindWidget onStatusChange={() => void loadMakers(true)} />
           </div>
         </header>
 

--- a/src/api/bitcoind.rs
+++ b/src/api/bitcoind.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{extract::State, http::StatusCode, routing::get, routing::post, Json, Router};
 use tokio::sync::Mutex;
+use tokio::time::sleep;
 
 use crate::maker_manager::{MakerConfig, MakerManager};
 
@@ -9,6 +11,8 @@ use super::{
     dto::{ApiResponse, BitcoindStatusInfo, StartBitcoindRequest},
     AppState,
 };
+
+const MAKER_AUTO_START_RETRY_DELAY: Duration = Duration::from_secs(5);
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -66,6 +70,11 @@ fn probe_standard_ports() -> Option<String> {
         }
     }
     None
+}
+
+async fn auto_start_makers_after_bitcoind_start(state: Arc<Mutex<MakerManager>>) {
+    sleep(MAKER_AUTO_START_RETRY_DELAY).await;
+    state.lock().await.auto_start_configured_makers();
 }
 
 /// Get bitcoind status by probing RPC connectivity via any registered maker's config.
@@ -139,14 +148,17 @@ async fn start(
 ) -> (StatusCode, Json<ApiResponse<BitcoindStatusInfo>>) {
     let network = body.network.clone();
     match state.lock().await.start_bitcoind(body.network) {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(ApiResponse::ok(BitcoindStatusInfo {
-                running: true,
-                network: Some(network),
-                managed: true,
-            })),
-        ),
+        Ok(()) => {
+            tokio::spawn(auto_start_makers_after_bitcoind_start(state.clone()));
+            (
+                StatusCode::OK,
+                Json(ApiResponse::ok(BitcoindStatusInfo {
+                    running: true,
+                    network: Some(network),
+                    managed: true,
+                })),
+            )
+        }
         Err(e) => (
             StatusCode::BAD_REQUEST,
             Json(ApiResponse::err(e.to_string())),

--- a/src/maker_manager/mod.rs
+++ b/src/maker_manager/mod.rs
@@ -177,9 +177,7 @@ impl MakerManager {
         if can_load {
             let saved_configs = mgr.persistence.load()?;
             mgr.restore_makers(saved_configs);
-            if mgr.settings.auto_start_makers {
-                mgr.auto_start_restored_makers();
-            }
+            mgr.auto_start_configured_makers();
             mgr.unlocked = true;
         }
 
@@ -227,15 +225,20 @@ impl MakerManager {
         }
     }
 
-    fn auto_start_restored_makers(&mut self) {
+    pub(crate) fn auto_start_configured_makers(&mut self) {
+        if !self.settings.auto_start_makers {
+            return;
+        }
+
         let restored_ids: Vec<MakerId> = self.configs.keys().cloned().collect();
         for id in restored_ids {
-            if self.pool.contains(&id) {
-                match self.pool.start_server(&id) {
-                    Ok(()) => tracing::info!("Maker '{}' auto-started after restore", id),
-                    Err(e) => {
-                        tracing::warn!("Maker '{}' restored but failed to auto-start: {}", id, e)
-                    }
+            match self.start_maker(&id) {
+                Ok(()) => {
+                    tracing::info!("Maker '{}' auto-started", id);
+                }
+                Err(MakerManagerError::AlreadyRunning(_)) => {}
+                Err(e) => {
+                    tracing::warn!("Maker '{}' failed to auto-start: {}", id, e);
                 }
             }
         }
@@ -254,9 +257,7 @@ impl MakerManager {
         self.persistence.update_enc_key(Some(key));
         let saved_configs = self.persistence.load()?;
         self.restore_makers(saved_configs);
-        if self.settings.auto_start_makers {
-            self.auto_start_restored_makers();
-        }
+        self.auto_start_configured_makers();
         self.unlocked = true;
 
         // If makers.json doesn't exist yet (fresh setup), persist an empty


### PR DESCRIPTION
Fixes #122 

Changes made:
- Backend: after the UI starts `bitcoind`, the API schedules a delayed maker auto-start retry so it does not race Bitcoin Core startup.
- Maker manager: auto-start now uses the normal `start_maker()` path, so makers whose pool entries were missing can be reinitialized from saved config.
- Frontend: after starting/stopping Bitcoin, the home page refreshes maker status immediately, and after starting Bitcoin it refreshes again a few seconds later for the green dots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maker data now auto-refreshes when the Bitcoin Core widget reports a status change.
  * After starting Bitcoin Core, makers can automatically begin a configured auto-start sequence shortly afterward.
  * Restored/configured makers automatically restart during manager initialization and unlock.
* **Refactor**
  * Auto-start logic was streamlined to consistently start configured makers and gracefully ignore “already running” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->