### PR TITLE
fix: Docker Compose maker data volume mounts

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,8 +67,8 @@ services:
       tor:
         condition: service_healthy
     volumes:
-      - dashboard-config:/root/.config/maker-dashboard
-      - coinswap-data:/root/.coinswap
+      - dashboard-config:/home/appuser/.config/maker-dashboard
+      - coinswap-data:/home/appuser/.coinswap
     environment:
       - MAKER_DASHBOARD_HOST=0.0.0.0
       - MAKER_DASHBOARD_PORT=${MAKER_DASHBOARD_PORT:-3000}


### PR DESCRIPTION
Currently on container recreation, the maker data does not persist, this pr intends to fix that by mounting dashboard and coinswap volumes under `appuser's home`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration for persistent data storage paths in the web service to ensure proper functionality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->