### PR TITLE
fix(backend): breaking change in `Wallet:coin_select`

### DIFF
--- a/src/maker_manager/maker_pool.rs
+++ b/src/maker_manager/maker_pool.rs
@@ -156,7 +156,7 @@ fn handle_request(
                 change_address_type: addr_type,
             };
             let coins_to_send = match maker.wallet().read() {
-                Ok(wallet) => match wallet.coin_select(amount, feerate, None, None) {
+                Ok(wallet) => match wallet.coin_select(amount, feerate, addr_type, None, None) {
                     Ok(coins) => coins,
                     Err(e) => {
                         return Ok(MessageResponse::ServerError(format!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address handling for send requests so the wallet now uses the maker’s address type during coin selection.
  * This helps ensure transactions are built with the correct address format while leaving the rest of the sending flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->